### PR TITLE
Switch references to i8 to c_char

### DIFF
--- a/common/src/extensions.rs
+++ b/common/src/extensions.rs
@@ -4,6 +4,7 @@
 //! implementation examples.
 
 use core::ffi::c_void;
+use std::os::raw::c_char;
 use std::ptr::NonNull;
 
 /// A marker struct that represents extensions implemented by the plugin side.
@@ -46,7 +47,7 @@ pub unsafe trait Extension: Sized + 'static {
     /// The standard identifier for this extension.
     ///
     /// This MUST point to a C-style, null-terminated string.
-    const IDENTIFIER: *const i8;
+    const IDENTIFIER: *const c_char;
     /// Whether this is a host extension or a plugin extension
     type ExtensionType: ExtensionType;
 

--- a/extensions/src/audio_ports.rs
+++ b/extensions/src/audio_ports.rs
@@ -5,6 +5,7 @@ use clap_sys::ext::audio_ports::*;
 use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
+use std::os::raw::c_char;
 use std::ptr::NonNull;
 
 pub use clap_sys::ext::audio_ports::{CLAP_PORT_MONO, CLAP_PORT_STEREO};
@@ -52,12 +53,12 @@ bitflags! {
 }
 
 unsafe impl Extension for PluginAudioPorts {
-    const IDENTIFIER: *const i8 = CLAP_EXT_AUDIO_PORTS;
+    const IDENTIFIER: *const c_char = CLAP_EXT_AUDIO_PORTS;
     type ExtensionType = PluginExtension;
 }
 
 unsafe impl Extension for HostAudioPorts {
-    const IDENTIFIER: *const i8 = CLAP_EXT_AUDIO_PORTS;
+    const IDENTIFIER: *const c_char = CLAP_EXT_AUDIO_PORTS;
     type ExtensionType = HostExtension;
 }
 

--- a/extensions/src/utils.rs
+++ b/extensions/src/utils.rs
@@ -1,7 +1,8 @@
 use std::cmp::min;
 use std::ffi::CStr;
+use std::os::raw::c_char;
 
-pub fn data_from_array_buf<const N: usize>(data: &[i8; N]) -> &[u8] {
+pub fn data_from_array_buf<const N: usize>(data: &[c_char; N]) -> &[u8] {
     // SAFETY: casting from i8 to u8 is safe
     let data = unsafe { ::core::slice::from_raw_parts(data.as_ptr() as *const _, data.len()) };
 
@@ -12,11 +13,11 @@ pub fn data_from_array_buf<const N: usize>(data: &[i8; N]) -> &[u8] {
 }
 
 #[inline]
-pub unsafe fn write_to_array_buf<const N: usize>(dst: *mut [i8; N], value: &[u8]) {
+pub unsafe fn write_to_array_buf<const N: usize>(dst: *mut [c_char; N], value: &[u8]) {
     let max_len = min(N - 1, value.len()); // Space for null byte
     let value = &value[..max_len];
     // SAFETY: casting from i8 to u8 is safe
-    let value = ::core::slice::from_raw_parts(value.as_ptr() as *const i8, value.len());
+    let value = ::core::slice::from_raw_parts(value.as_ptr() as *const c_char, value.len());
 
     let dst = dst.cast();
     core::ptr::copy_nonoverlapping(value.as_ptr(), dst, max_len);

--- a/plugin/src/extensions.rs
+++ b/plugin/src/extensions.rs
@@ -13,6 +13,7 @@
 //! information.
 //!
 //! ```
+//! # use std::os::raw::c_char;
 //! use clap_sys::ext::state::{CLAP_EXT_STATE, clap_plugin_state};
 //! use clack_common::extensions::{Extension, ExtensionImplementation, PluginExtension};
 //!
@@ -21,7 +22,7 @@
 //! pub struct PluginState(clap_plugin_state);
 //!
 //! unsafe impl Extension for PluginState {
-//!     const IDENTIFIER: *const i8 = CLAP_EXT_STATE;
+//!     const IDENTIFIER: *const c_char = CLAP_EXT_STATE;
 //!     type ExtensionType = PluginExtension;
 //! }
 //!

--- a/plugin/src/plugin/descriptor.rs
+++ b/plugin/src/plugin/descriptor.rs
@@ -1,6 +1,7 @@
 use clap_sys::plugin::clap_plugin_descriptor;
 use clap_sys::version::CLAP_VERSION;
 use std::ffi::CStr;
+use std::os::raw::c_char;
 
 #[repr(C)]
 pub struct PluginDescriptor(pub(crate) clap_plugin_descriptor);
@@ -12,13 +13,13 @@ impl PluginDescriptor {
         PluginDescriptor(clap_plugin_descriptor {
             clap_version: CLAP_VERSION,
             id: check_cstr(id).as_ptr(),
-            name: EMPTY.as_ptr() as *const i8,
-            vendor: EMPTY.as_ptr() as *const i8,
-            url: EMPTY.as_ptr() as *const i8,
-            manual_url: EMPTY.as_ptr() as *const i8,
-            version: EMPTY.as_ptr() as *const i8,
-            description: EMPTY.as_ptr() as *const i8,
-            support_url: EMPTY.as_ptr() as *const i8,
+            name: EMPTY.as_ptr() as *const c_char,
+            vendor: EMPTY.as_ptr() as *const c_char,
+            url: EMPTY.as_ptr() as *const c_char,
+            manual_url: EMPTY.as_ptr() as *const c_char,
+            version: EMPTY.as_ptr() as *const c_char,
+            description: EMPTY.as_ptr() as *const c_char,
+            support_url: EMPTY.as_ptr() as *const c_char,
             features: core::ptr::null(), // TODO: check with real features, there seems to be a crash somewhere
         })
     }


### PR DESCRIPTION
Attempting to build this on a `aarch64-unknown-linux-gnu` target reminded me that C `char`s can be `u8` instead of `i8` on some platforms. This changeset updates Clack to follow `clap_sys` in using `std::os::raw::c_char` across the board.