### PR TITLE
Implement the Voice Info extension for CLAP 1.1

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,5 +7,5 @@ rust-version = "1.59"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap-sys = "0.3.0"
+clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch="update/clap-1.1.0" }
 bitflags = "1.3.2"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -7,5 +7,5 @@ rust-version = "1.59"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch="update/clap-1.1.0" }
+clap-sys = { git = "https://github.com/glowcoil/clap-sys", rev="40f88806915368d72c265b578b27204f85d902b4" }
 bitflags = "1.3.2"

--- a/extensions/Cargo.toml
+++ b/extensions/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.59"
 clack-plugin = { path = "../plugin", optional = true }
 clack-host = { path = "../host", optional = true }
 clack-common = { path = "../common" }
-clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch="update/clap-1.1.0" }
+clap-sys = { git = "https://github.com/glowcoil/clap-sys", rev="40f88806915368d72c265b578b27204f85d902b4" }
 raw-window-handle = { version = "0.4.2", optional = true }
 bitflags = "1.3.2"
 

--- a/extensions/Cargo.toml
+++ b/extensions/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.59"
 clack-plugin = { path = "../plugin", optional = true }
 clack-host = { path = "../host", optional = true }
 clack-common = { path = "../common" }
-clap-sys = "0.3.0"
+clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch="update/clap-1.1.0" }
 raw-window-handle = { version = "0.4.2", optional = true }
 bitflags = "1.3.2"
 
@@ -49,3 +49,4 @@ tail = []
 thread-check = []
 thread-pool = []
 timer = []
+voice-info = []

--- a/extensions/src/lib.rs
+++ b/extensions/src/lib.rs
@@ -32,5 +32,7 @@ pub mod thread_check;
 pub mod thread_pool;
 #[cfg(feature = "timer")]
 pub mod timer;
+#[cfg(feature = "voice-info")]
+pub mod voice_info;
 
 pub(crate) mod utils;

--- a/extensions/src/voice_info.rs
+++ b/extensions/src/voice_info.rs
@@ -1,0 +1,197 @@
+//! Allows a synthesizer plugin to indicate the number of voices it has.
+//!
+//! It is useful for the host when performing polyphonic modulations,
+//! because the host needs its own voice management and should try to follow
+//! what the plugin is doing:
+//!
+//! * make the host's voice pool coherent with what the plugin has;
+//! * turn the host's voice management to mono when the plugin is mono.
+
+#![deny(missing_docs)]
+
+use bitflags::bitflags;
+use clack_common::extensions::{Extension, HostExtension};
+use clap_sys::ext::voice_info::*;
+use std::ffi::CStr;
+
+/// Plugin-side of the Voice Info extension.
+#[repr(C)]
+pub struct PluginVoiceInfo(clap_plugin_voice_info);
+
+// SAFETY: The API of this extension makes it so that the Send/Sync requirements are enforced onto
+// the input handles, not on the descriptor itself.
+unsafe impl Send for PluginVoiceInfo {}
+unsafe impl Sync for PluginVoiceInfo {}
+
+unsafe impl Extension for PluginVoiceInfo {
+    const IDENTIFIER: &'static CStr = CLAP_EXT_VOICE_INFO;
+    type ExtensionType = HostExtension;
+}
+
+/// Host-side of the Voice Info extension.
+#[repr(C)]
+pub struct HostVoiceInfo(clap_host_voice_info);
+
+// SAFETY: The API of this extension makes it so that the Send/Sync requirements are enforced onto
+// the input handles, not on the descriptor itself.
+unsafe impl Send for HostVoiceInfo {}
+unsafe impl Sync for HostVoiceInfo {}
+
+unsafe impl Extension for HostVoiceInfo {
+    const IDENTIFIER: &'static CStr = CLAP_EXT_VOICE_INFO;
+    type ExtensionType = HostExtension;
+}
+
+bitflags! {
+    /// Option flags for [`VoiceInfo`].
+    #[repr(C)]
+    pub struct VoiceInfoFlags: u64 {
+        /// Allows the host to send overlapping NOTE_On events.
+        /// The plugin will then have to rely upon the note_id to distinguish between the different notes.
+        const SUPPORTS_OVERLAPPING_NOTES = CLAP_VOICE_INFO_SUPPORTS_OVERLAPPING_NOTES;
+    }
+}
+
+/// A plugin's voice information.
+pub struct VoiceInfo {
+    /// The current number of voices the patch can use.
+    ///
+    /// If this is 1, then the synth is working in mono, and the host can decide to only use global
+    /// modulation mapping.
+    pub voice_count: u32,
+    /// The maximum number of voice the synthesizer can output at the same time.
+    pub voice_capacity: u32,
+    /// Options for voice information, see [`VoiceInfoFlags`].
+    pub flags: VoiceInfoFlags,
+}
+
+impl VoiceInfo {
+    #[inline]
+    fn from_raw(raw: &clap_voice_info) -> Self {
+        Self {
+            voice_count: raw.voice_count,
+            voice_capacity: raw.voice_capacity,
+            flags: VoiceInfoFlags::from_bits_truncate(raw.flags),
+        }
+    }
+
+    #[inline]
+    fn to_raw(&self) -> clap_voice_info {
+        clap_voice_info {
+            voice_count: self.voice_count,
+            voice_capacity: self.voice_capacity,
+            flags: self.flags.bits,
+        }
+    }
+}
+
+#[cfg(feature = "clack-host")]
+mod host {
+    use super::*;
+    use clack_common::extensions::ExtensionImplementation;
+    use clack_host::host::Host;
+    use clack_host::plugin::PluginMainThreadHandle;
+    use clack_host::wrapper::HostWrapper;
+    use clap_sys::host::clap_host;
+    use std::mem::MaybeUninit;
+
+    impl PluginVoiceInfo {
+        /// Retrieves a plugin's Voice Information.
+        ///
+        /// If the plugin failed to provide any Voice Information, this returns [`None`].
+        pub fn get(&self, plugin: &mut PluginMainThreadHandle) -> Option<VoiceInfo> {
+            let info = MaybeUninit::uninit();
+
+            let success = unsafe { self.0.get?(plugin.as_raw(), info.as_ptr() as *mut _) };
+
+            // SAFETY: we only read the buffer if the plugin returned a successful state
+            unsafe { success.then(|| VoiceInfo::from_raw(info.assume_init_ref())) }
+        }
+    }
+
+    /// Implementation of the Host-side of the Voice Info extension.
+    pub trait HostVoiceInfoImplementation {
+        /// Indicates the plugin has changed its voice configuration, and the host needs to update
+        /// it by calling [`get`](PluginVoiceInfo::get) again.
+        fn changed(&mut self);
+    }
+
+    impl<H: for<'a> Host<'a>> ExtensionImplementation<H> for HostVoiceInfo
+    where
+        for<'a> <H as Host<'a>>::MainThread: HostVoiceInfoImplementation,
+    {
+        const IMPLEMENTATION: &'static Self = &Self(clap_host_voice_info {
+            changed: Some(changed::<H>),
+        });
+    }
+
+    unsafe extern "C" fn changed<H: for<'a> Host<'a>>(host: *const clap_host)
+    where
+        for<'a> <H as Host<'a>>::MainThread: HostVoiceInfoImplementation,
+    {
+        HostWrapper::<H>::handle(host, |host| {
+            host.main_thread().as_mut().changed();
+            Ok(())
+        });
+    }
+}
+
+#[cfg(feature = "clack-host")]
+pub use host::*;
+
+#[cfg(feature = "clack-plugin")]
+mod plugin {
+    use super::*;
+    use clack_common::extensions::ExtensionImplementation;
+    use clack_plugin::host::HostMainThreadHandle;
+    use clack_plugin::plugin::wrapper::PluginWrapper;
+    use clack_plugin::plugin::Plugin;
+    use clap_sys::plugin::clap_plugin;
+
+    impl HostVoiceInfo {
+        /// Indicates the plugin has changed its voice configuration, and the host needs to update
+        /// it by calling [`get`](PluginVoiceInfoImplementation::get) again.
+        pub fn changed(&self, host: &mut HostMainThreadHandle) {
+            if let Some(changed) = self.0.changed {
+                unsafe { changed(host.as_raw()) }
+            }
+        }
+    }
+
+    /// Implementation of the Plugin-side of the Voice Info extension.
+    pub trait PluginVoiceInfoImplementation {
+        /// Retrieves a plugin's Voice Information.
+        ///
+        /// If the plugin failed to provide any Voice Information, this returns [`None`].
+        fn get(&self) -> Option<VoiceInfo>;
+    }
+
+    impl<P: for<'a> Plugin<'a>> ExtensionImplementation<P> for PluginVoiceInfo
+    where
+        for<'a> <P as Plugin<'a>>::MainThread: PluginVoiceInfoImplementation,
+    {
+        const IMPLEMENTATION: &'static Self = &Self(clap_plugin_voice_info {
+            get: Some(get::<P>),
+        });
+    }
+
+    unsafe extern "C" fn get<P: for<'a> Plugin<'a>>(
+        plugin: *const clap_plugin,
+        info: *mut clap_voice_info,
+    ) -> bool
+    where
+        for<'a> <P as Plugin<'a>>::MainThread: PluginVoiceInfoImplementation,
+    {
+        PluginWrapper::<P>::handle(plugin, |plugin| match plugin.main_thread().as_mut().get() {
+            None => Ok(false),
+            Some(voice_info) => {
+                *info = voice_info.to_raw();
+                Ok(true)
+            }
+        })
+        .unwrap_or(false)
+    }
+}
+
+#[cfg(feature = "clack-plugin")]
+pub use plugin::*;

--- a/extensions/src/voice_info.rs
+++ b/extensions/src/voice_info.rs
@@ -110,7 +110,7 @@ mod host {
     }
 
     /// Implementation of the Host-side of the Voice Info extension.
-    pub trait HostVoiceInfoImplementation {
+    pub trait HostVoiceInfoImpl {
         /// Indicates the plugin has changed its voice configuration, and the host needs to update
         /// it by calling [`get`](PluginVoiceInfo::get) again.
         fn changed(&mut self);
@@ -118,7 +118,7 @@ mod host {
 
     impl<H: for<'a> Host<'a>> ExtensionImplementation<H> for HostVoiceInfo
     where
-        for<'a> <H as Host<'a>>::MainThread: HostVoiceInfoImplementation,
+        for<'a> <H as Host<'a>>::MainThread: HostVoiceInfoImpl,
     {
         const IMPLEMENTATION: &'static Self = &Self(clap_host_voice_info {
             changed: Some(changed::<H>),
@@ -127,7 +127,7 @@ mod host {
 
     unsafe extern "C" fn changed<H: for<'a> Host<'a>>(host: *const clap_host)
     where
-        for<'a> <H as Host<'a>>::MainThread: HostVoiceInfoImplementation,
+        for<'a> <H as Host<'a>>::MainThread: HostVoiceInfoImpl,
     {
         HostWrapper::<H>::handle(host, |host| {
             host.main_thread().as_mut().changed();
@@ -150,7 +150,7 @@ mod plugin {
 
     impl HostVoiceInfo {
         /// Indicates the plugin has changed its voice configuration, and the host needs to update
-        /// it by calling [`get`](PluginVoiceInfoImplementation::get) again.
+        /// it by calling [`get`](PluginVoiceInfoImpl::get) again.
         pub fn changed(&self, host: &mut HostMainThreadHandle) {
             if let Some(changed) = self.0.changed {
                 unsafe { changed(host.as_raw()) }
@@ -159,7 +159,7 @@ mod plugin {
     }
 
     /// Implementation of the Plugin-side of the Voice Info extension.
-    pub trait PluginVoiceInfoImplementation {
+    pub trait PluginVoiceInfoImpl {
         /// Retrieves a plugin's Voice Information.
         ///
         /// If the plugin failed to provide any Voice Information, this returns [`None`].
@@ -168,7 +168,7 @@ mod plugin {
 
     impl<P: for<'a> Plugin<'a>> ExtensionImplementation<P> for PluginVoiceInfo
     where
-        for<'a> <P as Plugin<'a>>::MainThread: PluginVoiceInfoImplementation,
+        for<'a> <P as Plugin<'a>>::MainThread: PluginVoiceInfoImpl,
     {
         const IMPLEMENTATION: &'static Self = &Self(clap_plugin_voice_info {
             get: Some(get::<P>),
@@ -180,7 +180,7 @@ mod plugin {
         info: *mut clap_voice_info,
     ) -> bool
     where
-        for<'a> <P as Plugin<'a>>::MainThread: PluginVoiceInfoImplementation,
+        for<'a> <P as Plugin<'a>>::MainThread: PluginVoiceInfoImpl,
     {
         PluginWrapper::<P>::handle(plugin, |plugin| match plugin.main_thread().as_mut().get() {
             None => Ok(false),

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.59"
 
 [dependencies]
-clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch="update/clap-1.1.0" }
+clap-sys = { git = "https://github.com/glowcoil/clap-sys", rev="40f88806915368d72c265b578b27204f85d902b4" }
 clack-common = { path = "../common" }
 libloading = "0.7.2"
 selfie = "=0.0.2"

--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.59"
 
 [dependencies]
-clap-sys = "0.3.0"
+clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch="update/clap-1.1.0" }
 clack-common = { path = "../common" }
 libloading = "0.7.2"
 selfie = "=0.0.2"

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -8,5 +8,5 @@ rust-version = "1.59"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch="update/clap-1.1.0" }
+clap-sys = { git = "https://github.com/glowcoil/clap-sys", rev="40f88806915368d72c265b578b27204f85d902b4" }
 clack-common = { path = "../common" }

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -8,5 +8,5 @@ rust-version = "1.59"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap-sys = "0.3.0"
+clap-sys = { git = "https://github.com/robbert-vdh/clap-sys.git", branch="update/clap-1.1.0" }
 clack-common = { path = "../common" }


### PR DESCRIPTION
TODO: change to the crates.io version of `clap-sys` when glowcoil/clap-sys#19 is merged.