### PR TITLE
Implement description for StaticPluginDescriptor

### DIFF
--- a/plugin/src/plugin/descriptor.rs
+++ b/plugin/src/plugin/descriptor.rs
@@ -152,6 +152,11 @@ impl PluginDescriptor for StaticPluginDescriptor {
     }
 
     #[inline]
+    fn description(&self) -> Option<&CStr> {
+        self.description
+    }
+
+    #[inline]
     fn features(&self) -> Option<&[&CStr]> {
         self.features
     }


### PR DESCRIPTION
`StaticPluginDescriptor` is missing the implementation for `description`.