### PR TITLE
Fix concurrently loading a bundle multiple times

### DIFF
--- a/host/src/bundle.rs
+++ b/host/src/bundle.rs
@@ -115,10 +115,9 @@ impl PluginBundle {
     /// ```
     pub fn load<P: AsRef<OsStr>>(path: P) -> Result<Self, PluginBundleError> {
         let path = path.as_ref();
+        let path_str = path.to_str().ok_or(PluginBundleError::InvalidUtf8Path)?;
 
         let library = PluginEntryLibrary::load(path)?;
-
-        let path_str = path.to_str().ok_or(PluginBundleError::InvalidUtf8Path)?;
 
         let inner = unsafe { cache::load_from_library(library, path_str)? };
 

--- a/host/src/bundle/cache.rs
+++ b/host/src/bundle/cache.rs
@@ -1,0 +1,134 @@
+use crate::bundle::entry::LoadedEntry;
+use crate::bundle::library::PluginEntryLibrary;
+use crate::bundle::PluginBundleError;
+use clack_common::entry::EntryDescriptor;
+use selfie::refs::RefType;
+use selfie::Selfie;
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex, OnceLock};
+
+#[derive(Hash, Eq, PartialEq)]
+struct EntryPointer(*const EntryDescriptor);
+
+unsafe impl Send for EntryPointer {}
+unsafe impl Sync for EntryPointer {}
+
+static ENTRY_CACHE: OnceLock<Mutex<HashMap<EntryPointer, Arc<EntrySourceInner>>>> = OnceLock::new();
+
+unsafe fn get_or_insert(
+    entry_pointer: EntryPointer,
+    load_entry: impl FnOnce() -> Result<EntrySourceInner, PluginBundleError>,
+) -> Result<CachedEntry, PluginBundleError> {
+    // dbg!("Loading", ::std::thread::current().id());
+    let cache = ENTRY_CACHE
+        .get_or_init(|| Mutex::new(HashMap::new()))
+        .lock();
+
+    // dbg!("Locked for loading", ::std::thread::current().id());
+    let mut cache = match cache {
+        Ok(guard) => guard,
+        Err(e) => e.into_inner(),
+    };
+
+    let s = match cache.entry(entry_pointer) {
+        Entry::Occupied(e) => Arc::clone(e.get()),
+        Entry::Vacant(e) => {
+            let entry_source = Arc::new(load_entry()?);
+            e.insert(Arc::clone(&entry_source));
+            entry_source
+        }
+    };
+
+    drop(cache);
+    // dbg!("Unlocked for loading.", ::std::thread::current().id());
+
+    Ok(CachedEntry(Some(s)))
+}
+
+pub(crate) unsafe fn load_from_library(
+    library: PluginEntryLibrary,
+    plugin_path: &str,
+) -> Result<CachedEntry, PluginBundleError> {
+    get_or_insert(EntryPointer(library.entry()), move || {
+        Ok(EntrySourceInner::FromLibrary(
+            Selfie::try_new(Pin::new(library), |entry| unsafe {
+                LoadedEntry::load(entry, plugin_path)
+            })
+            // The library can be discarded completely
+            .map_err(|e| e.error)?,
+        ))
+    })
+}
+
+pub(crate) unsafe fn load_from_raw(
+    entry_descriptor: &'static EntryDescriptor,
+    plugin_path: &str,
+) -> Result<CachedEntry, PluginBundleError> {
+    get_or_insert(EntryPointer(entry_descriptor), || {
+        Ok(EntrySourceInner::FromRaw(LoadedEntry::load(
+            entry_descriptor,
+            plugin_path,
+        )?))
+    })
+}
+
+pub(crate) struct LoadedEntryRef;
+
+impl<'a> RefType<'a> for LoadedEntryRef {
+    type Ref = LoadedEntry<'a>;
+}
+
+enum EntrySourceInner {
+    FromRaw(LoadedEntry<'static>),
+    FromLibrary(Selfie<'static, PluginEntryLibrary, LoadedEntryRef>),
+}
+
+#[derive(Clone)]
+pub(crate) struct CachedEntry(Option<Arc<EntrySourceInner>>);
+
+impl CachedEntry {
+    #[inline]
+    pub(crate) fn raw_entry(&self) -> &EntryDescriptor {
+        let Some(entry) = &self.0 else {
+            unreachable!("Unloaded state only exists during CachedEntry's Drop implementation")
+        };
+
+        match entry.as_ref() {
+            EntrySourceInner::FromRaw(raw) => raw.entry(),
+            EntrySourceInner::FromLibrary(bundle) => bundle.with_referential(|e| e.entry()),
+        }
+    }
+}
+
+impl Drop for CachedEntry {
+    fn drop(&mut self) {
+        let ptr = EntryPointer(self.raw_entry());
+
+        // Drop the Arc. If it was the only one outside of the cache, then its refcount should be 1.
+        self.0 = None;
+
+        // dbg!("Unloading", ::std::thread::current().id());
+        let cache = ENTRY_CACHE
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock();
+
+        // dbg!("Locked for unloading", ::std::thread::current().id());
+
+        let mut cache = match cache {
+            Ok(guard) => guard,
+            Err(e) => e.into_inner(),
+        };
+
+        if let Entry::Occupied(mut o) = cache.entry(ptr) {
+            if Arc::get_mut(o.get_mut()).is_some() {
+                o.remove();
+            }
+        }
+
+        drop(cache);
+
+        // dbg!("Unlocked for unloading", ::std::thread::current().id());
+    }
+}

--- a/host/src/bundle/library.rs
+++ b/host/src/bundle/library.rs
@@ -1,0 +1,51 @@
+use crate::bundle::PluginBundleError;
+use clack_common::entry::EntryDescriptor;
+use libloading::Library;
+use stable_deref_trait::StableDeref;
+use std::ffi::OsStr;
+use std::ops::Deref;
+use std::ptr::NonNull;
+
+pub(crate) struct PluginEntryLibrary {
+    _library: Library,
+    entry_ptr: NonNull<EntryDescriptor>,
+}
+
+const SYMBOL_NAME: &[u8] = b"clap_entry\0";
+impl PluginEntryLibrary {
+    pub fn load(path: &OsStr) -> Result<Self, PluginBundleError> {
+        let library =
+            unsafe { Library::new(path) }.map_err(PluginBundleError::LibraryLoadingError)?;
+
+        let symbol = unsafe { library.get::<*const EntryDescriptor>(SYMBOL_NAME) }
+            .map_err(PluginBundleError::LibraryLoadingError)?;
+
+        let entry_ptr = NonNull::new(*symbol as *mut EntryDescriptor)
+            .ok_or(PluginBundleError::NullEntryPointer)?;
+
+        Ok(Self {
+            _library: library,
+            entry_ptr,
+        })
+    }
+
+    #[inline]
+    pub fn entry(&self) -> &EntryDescriptor {
+        unsafe { self.entry_ptr.as_ref() }
+    }
+}
+
+impl Deref for PluginEntryLibrary {
+    type Target = EntryDescriptor;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.entry()
+    }
+}
+
+unsafe impl StableDeref for PluginEntryLibrary {}
+
+// SAFETY: Entries and factories are all thread-safe by the CLAP spec
+unsafe impl Send for PluginEntryLibrary {}
+unsafe impl Sync for PluginEntryLibrary {}

--- a/host/tests/instance.rs
+++ b/host/tests/instance.rs
@@ -102,7 +102,7 @@ pub fn it_works_concurrently_with_static_entrypoint() {
     let entrypoint = &DIVA_STUB_ENTRY;
 
     std::thread::scope(|s| {
-        for i in 0..300 {
+        for i in 0..50 {
             std::thread::Builder::new()
                 .name(format!("Test {i}"))
                 .spawn_scoped(s, move || {

--- a/host/tests/loading.rs
+++ b/host/tests/loading.rs
@@ -19,3 +19,29 @@ pub fn it_works() {
         .unwrap();
     assert_eq!(desc.id().unwrap().to_bytes(), b"org.rust-audio.clack.gain");
 }
+
+#[test]
+#[cfg_attr(miri, ignore)] // Miri does not support calling foreign function (dlopen)
+pub fn it_works_concurrently() {
+    let bundle_path = format!(
+        "{}/../target/debug/{}gain{}",
+        env!("CARGO_MANIFEST_DIR"),
+        std::env::consts::DLL_PREFIX,
+        std::env::consts::DLL_SUFFIX
+    );
+
+    std::thread::scope(|s| {
+        for _ in 0..300 {
+            s.spawn(|| {
+                let bundle = PluginBundle::load(&bundle_path).unwrap();
+
+                let desc = bundle
+                    .get_factory::<PluginFactory>()
+                    .unwrap()
+                    .plugin_descriptor(0)
+                    .unwrap();
+                assert_eq!(desc.id().unwrap().to_bytes(), b"org.rust-audio.clack.gain");
+            });
+        }
+    })
+}


### PR DESCRIPTION
This PR fixes various concurrency issues that may occur when loading and unloading `PluginBundle`s multiple times in the lifetime of an host process (as reported by @jaxter184 on Discord).

This new implementation allows plugin entry points to be re-loaded from the same DSO/address space after it has been unloaded, following the discussion in free-audio/clap#365.

This PR does not make any changes to public-facing APIs.