### PR TITLE
Bugfix | Polysynth | Oscillator | Fixes crash on stopping non playing note

### DIFF
--- a/plugin/examples/polysynth/src/poly_oscillator.rs
+++ b/plugin/examples/polysynth/src/poly_oscillator.rs
@@ -73,6 +73,11 @@ impl PolyOscillator {
 
         // Find the voice that is playing that note.
         if let Some(voice_index) = voice_index {
+            if voice_index >= self.active_voice_count {
+                // the voice is not playing
+                return;
+            }
+
             // Swap the targeted voice with the last one.
             self.voice_buffer
                 .swap(voice_index, self.active_voice_count - 1);


### PR DESCRIPTION
## The Bug

The [clap-validator](https://github.com/free-audio/clap-validator) highlighted a crash in the polysynth example plugin. The `PolyOscillator::stop_voice` is missing a check to ensure that the note which needs stopping is indeed playing.  

You only hit the bug if the polysynth gets called to stop a note which is not playing. This means that you will be unlikely to hit it in a "normal" session. Of course this use case should still be supported.

## The Fix

When the oscillator stops a voice it doesn't suffice to only check all voice which match that note, because they may not be active - they could have been already stopped - we must additionally check that the voice is currently active.