### PR TITLE
Feature | Plugin Examples | Add Bundle Helper

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --release --"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,9 @@ members = [
     "plugin",
     "plugin/examples/gain",
     "plugin/examples/polysynth",
+    "plugin/examples/xtask",
     "extensions",
-    "test-host"
+    "test-host",
 ]
 
 [workspace.dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -41,7 +41,11 @@ unknown-registry = "deny"
 unknown-git = "deny"
 # List of URLs for allowed Git repositories
 allow-git = [
-    "https://github.com/prokopyl/selfie",
     "https://github.com/glowcoil/clap-sys",
+    "https://github.com/prokopyl/selfie",
+
+    # for nih_plug_xtask
+    "https://github.com/robbert-vdh/nih-plug.git",
+    "https://github.com/nicokoch/reflink.git",
 ]
 

--- a/plugin/examples/polysynth/README.md
+++ b/plugin/examples/polysynth/README.md
@@ -21,19 +21,18 @@ off the various parts of the Clack API by implementing the following features:
 
 ## Building and installing from source
 
-To build this example from source, move (`cd`) to the directory containing
-the Clack source code, and you can build the example using `cargo` like so:
+We use the [xtask compile helper from ni-plug](https://github.com/robbert-vdh/nih-plug/blob/master/nih_plug_xtask/README.md)
+to build this example from source and handle the bundling of the binary dynamic library output from Cargo.
+Run the following command from the root of the Clack repository.
 
 ```shell
-cargo build -p clack-plugin-polysynth --release
+cargo xtask bundle -p clack-plugin-polysynth --release
 ```
 
-This will create a `clack_plugin_polysynth` library file (suffix may vary depending on
-your Operating System) in the `target/release` directory. 
+This will create a `clack-plugin-polysynth.clap` file in the `target/bundled` directory. 
 
-You can then copy (or link) that file to your CLAP plugin directory, and renaming it
-with a `.clap` extension (e.g. `clack_plugin_polysynth.clap`). This will enable it to
-be picked up by your CLAP DAWs and hosts.
+You can then copy (or link) that file to your CLAP plugin directory.
+This will enable it to be picked up by your CLAP DAWs and hosts.
 
 ## Usage
 

--- a/plugin/examples/xtask/Cargo.toml
+++ b/plugin/examples/xtask/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+nih_plug_xtask = { git = "https://github.com/robbert-vdh/nih-plug.git" }

--- a/plugin/examples/xtask/Cargo.toml
+++ b/plugin/examples/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 version = "0.1.0"
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
-nih_plug_xtask = { git = "https://github.com/robbert-vdh/nih-plug.git" }
+nih_plug_xtask = { git = "https://github.com/robbert-vdh/nih-plug.git", version = "0.1.0" }

--- a/plugin/examples/xtask/src/main.rs
+++ b/plugin/examples/xtask/src/main.rs
@@ -1,0 +1,3 @@
+fn main() -> nih_plug_xtask::Result<()> {
+    nih_plug_xtask::main()
+}


### PR DESCRIPTION
## The Feature

Adds a bundle helper to the plugin examples.  This utility handles the renaming of the dynamic library output from Cargo, adding the `.clap` suffix. On macOS it also handles the bundling of the binary into a bundle with a `Info.plist`, etc.

The xtask utility itself is from [nih-plug](https://github.com/robbert-vdh/nih-plug/blob/master/nih_plug_xtask/README.md)

## Testing

Requires testing on 

- [x] macOS
- [ ] Windows
- [ ] Linux

## Caveats

Because the tool is from nih-plug, the `CFBundleIdentifier` in the generated macos `Info.plist` file will be `com.nih-plug.clack-plugin-polysynth`. We could request additional customisation on the tool which would allow us to override the `com.nih-plug` prefix in the identifier string - perhaps in a later refinement.

## Alternatives

Unfortunately [cargo-bundle](https://github.com/burtonageo/cargo-bundle) does not have the flexibility that is required to bundle a CLAP plugin. We cannot add a custom bundle suffix and it's incompatible with "cdylib" crate types.

A quick and dirty alternative could also be to add a shell script which does the renaming / bundling. Builders would run the script after running the basic `cargo build`. Of course, this option comes with the added overhead of maintaining the scripts themselves. It's also less neat than the xtask which acts like a Cargo extension and allows the examples to be DAW-ready with just one command.

A further alternative would be to fork the xtask utility into clack.