### PR TITLE
Mutability changes for plugin handles

### DIFF
--- a/extensions/src/audio_ports/host.rs
+++ b/extensions/src/audio_ports/host.rs
@@ -24,7 +24,7 @@ impl AudioPortInfoBuffer {
 }
 
 impl PluginAudioPorts {
-    pub fn count(&self, plugin: &PluginMainThreadHandle, is_input: bool) -> u32 {
+    pub fn count(&self, plugin: &mut PluginMainThreadHandle, is_input: bool) -> u32 {
         match self.0.count {
             None => 0,
             Some(count) => unsafe { count(plugin.as_raw(), is_input) },
@@ -33,7 +33,7 @@ impl PluginAudioPorts {
 
     pub fn get<'b>(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         index: u32,
         is_input: bool,
         buffer: &'b mut AudioPortInfoBuffer,

--- a/extensions/src/audio_ports/plugin.rs
+++ b/extensions/src/audio_ports/plugin.rs
@@ -52,8 +52,8 @@ impl<'a> AudioPortInfoWriter<'a> {
 }
 
 pub trait PluginAudioPortsImpl {
-    fn count(&self, is_input: bool) -> u32;
-    fn get(&self, is_input: bool, index: u32, writer: &mut AudioPortInfoWriter);
+    fn count(&mut self, is_input: bool) -> u32;
+    fn get(&mut self, is_input: bool, index: u32, writer: &mut AudioPortInfoWriter);
 }
 
 impl<P: Plugin> ExtensionImplementation<P> for PluginAudioPorts
@@ -73,7 +73,7 @@ unsafe extern "C" fn count<P: Plugin>(plugin: *const clap_plugin, is_input: bool
 where
     for<'a> P::MainThread<'a>: PluginAudioPortsImpl,
 {
-    PluginWrapper::<P>::handle(plugin, |p| Ok(p.main_thread().as_ref().count(is_input)))
+    PluginWrapper::<P>::handle(plugin, |p| Ok(p.main_thread().as_mut().count(is_input)))
         .unwrap_or(0)
 }
 
@@ -92,7 +92,7 @@ where
         };
 
         let mut writer = AudioPortInfoWriter::from_raw(info);
-        p.main_thread().as_ref().get(is_input, index, &mut writer);
+        p.main_thread().as_mut().get(is_input, index, &mut writer);
         Ok(writer.is_set)
     })
     .unwrap_or(false)

--- a/extensions/src/audio_ports_config/host.rs
+++ b/extensions/src/audio_ports_config/host.rs
@@ -27,7 +27,7 @@ impl AudioPortsConfigBuffer {
 
 impl PluginAudioPortsConfig {
     /// Returns the number of available [`AudioPortsConfiguration`]s.
-    pub fn count(&self, plugin: &PluginMainThreadHandle) -> usize {
+    pub fn count(&self, plugin: &mut PluginMainThreadHandle) -> usize {
         match self.0.count {
             None => 0,
             Some(count) => unsafe { count(plugin.as_raw()) as usize },
@@ -40,7 +40,7 @@ impl PluginAudioPortsConfig {
     /// unnecessary allocations.
     pub fn get<'b>(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         index: usize,
         buffer: &'b mut AudioPortsConfigBuffer,
     ) -> Option<AudioPortsConfiguration<'b>> {

--- a/extensions/src/audio_ports_config/plugin.rs
+++ b/extensions/src/audio_ports_config/plugin.rs
@@ -7,13 +7,13 @@ use std::ptr::addr_of_mut;
 /// Implementation of the Plugin-side of the Audio Ports Configuration extension.
 pub trait PluginAudioPortsConfigImpl {
     /// Returns the number of available [`AudioPortsConfiguration`]s.
-    fn count(&self) -> u32;
+    fn count(&mut self) -> u32;
 
     /// Retrieves a specific [`AudioPortsConfiguration`] from its index.
     ///
     /// The plugin gets passed a host-provided mutable buffer to write the configuration into, to
     /// avoid any unnecessary allocations.
-    fn get(&self, index: u32, writer: &mut AudioPortConfigWriter);
+    fn get(&mut self, index: u32, writer: &mut AudioPortConfigWriter);
 
     /// Requests the plugin to change its Audio Ports Configuration to the one with the given ID.
     ///
@@ -42,7 +42,7 @@ unsafe extern "C" fn count<P: Plugin>(plugin: *const clap_plugin) -> u32
 where
     for<'a> P::MainThread<'a>: PluginAudioPortsConfigImpl,
 {
-    PluginWrapper::<P>::handle(plugin, |p| Ok(p.main_thread().as_ref().count())).unwrap_or(0)
+    PluginWrapper::<P>::handle(plugin, |p| Ok(p.main_thread().as_mut().count())).unwrap_or(0)
 }
 
 unsafe extern "C" fn get<P: Plugin>(
@@ -59,7 +59,7 @@ where
         };
 
         let mut writer = AudioPortConfigWriter::from_raw(config);
-        p.main_thread().as_ref().get(index, &mut writer);
+        p.main_thread().as_mut().get(index, &mut writer);
         Ok(writer.is_set)
     })
     .unwrap_or(false)

--- a/extensions/src/gui.rs
+++ b/extensions/src/gui.rs
@@ -411,7 +411,7 @@ impl<'a> GuiApiType<'a> {
     /// [`X11`](Self::X11) on other Unix OSes.
     #[inline]
     #[allow(unreachable_code)]
-    pub fn default_for_current_platform() -> Option<Self> {
+    pub const fn default_for_current_platform() -> Option<Self> {
         #[cfg(target_os = "windows")]
         return Some(Self::WIN32);
         #[cfg(target_os = "macos")]

--- a/extensions/src/gui/host.rs
+++ b/extensions/src/gui/host.rs
@@ -5,7 +5,7 @@ impl PluginGui {
     /// Indicate whether a particular API is supported.
     pub fn is_api_supported(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         configuration: GuiConfiguration,
     ) -> bool {
         match self.inner.is_api_supported {
@@ -23,7 +23,10 @@ impl PluginGui {
     ///
     /// This is __only a hint__ however, and the host can still use the API of its choice and/or
     /// situate the plugin in floating or embedded state despite having called this.
-    pub fn get_preferred_api(&self, plugin: &PluginMainThreadHandle) -> Option<GuiConfiguration> {
+    pub fn get_preferred_api(
+        &self,
+        plugin: &mut PluginMainThreadHandle,
+    ) -> Option<GuiConfiguration> {
         let mut api_type = core::ptr::null();
         let mut is_floating = true;
 
@@ -93,7 +96,7 @@ impl PluginGui {
     }
 
     /// Get current size of GUI
-    pub fn get_size(&self, plugin: &PluginMainThreadHandle) -> Option<GuiSize> {
+    pub fn get_size(&self, plugin: &mut PluginMainThreadHandle) -> Option<GuiSize> {
         let mut width = 0;
         let mut height = 0;
 
@@ -109,7 +112,7 @@ impl PluginGui {
     /// Tell host if GUI can be resized
     ///
     /// Only applies to embedded windows.
-    pub fn can_resize(&self, plugin: &PluginMainThreadHandle) -> bool {
+    pub fn can_resize(&self, plugin: &mut PluginMainThreadHandle) -> bool {
         if let Some(can_resize) = self.inner.can_resize {
             unsafe { can_resize(plugin.as_raw()) }
         } else {
@@ -118,7 +121,7 @@ impl PluginGui {
     }
 
     /// Provide hints on the resize-ability of the GUI
-    pub fn get_resize_hints(&self, plugin: &PluginMainThreadHandle) -> Option<GuiResizeHints> {
+    pub fn get_resize_hints(&self, plugin: &mut PluginMainThreadHandle) -> Option<GuiResizeHints> {
         let mut hints = clap_gui_resize_hints {
             aspect_ratio_height: u32::MAX,
             aspect_ratio_width: u32::MAX,

--- a/extensions/src/note_name/host.rs
+++ b/extensions/src/note_name/host.rs
@@ -27,7 +27,7 @@ impl NoteNameBuffer {
 
 impl PluginNoteName {
     /// Returns the number of available [`NoteName`]s.
-    pub fn count(&self, plugin: &PluginMainThreadHandle) -> usize {
+    pub fn count(&self, plugin: &mut PluginMainThreadHandle) -> usize {
         match self.0.count {
             None => 0,
             Some(count) => unsafe { count(plugin.as_raw()) as usize },
@@ -40,7 +40,7 @@ impl PluginNoteName {
     /// unnecessary allocations.
     pub fn get<'b>(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         index: usize,
         buffer: &'b mut NoteNameBuffer,
     ) -> Option<NoteName<'b>> {

--- a/extensions/src/note_name/plugin.rs
+++ b/extensions/src/note_name/plugin.rs
@@ -7,13 +7,13 @@ use std::ptr::addr_of_mut;
 /// Implementation of the Plugin-side of the Note Name extension.
 pub trait PluginNoteNameImpl {
     /// Returns the number of available [`NoteName`]s.
-    fn count(&self) -> usize;
+    fn count(&mut self) -> usize;
 
     /// Retrieves a specific [`NoteName`] from its index.
     ///
     /// The plugin gets passed a host-provided mutable buffer to write the configuration into, to
     /// avoid any unnecessary allocations.
-    fn get(&self, index: usize, writer: &mut NoteNameWriter);
+    fn get(&mut self, index: usize, writer: &mut NoteNameWriter);
 }
 
 impl<P: Plugin> ExtensionImplementation<P> for PluginNoteName
@@ -31,7 +31,7 @@ unsafe extern "C" fn count<P: Plugin>(plugin: *const clap_plugin) -> u32
 where
     for<'a> P::MainThread<'a>: PluginNoteNameImpl,
 {
-    PluginWrapper::<P>::handle(plugin, |p| Ok(p.main_thread().as_ref().count() as u32)).unwrap_or(0)
+    PluginWrapper::<P>::handle(plugin, |p| Ok(p.main_thread().as_mut().count() as u32)).unwrap_or(0)
 }
 
 unsafe extern "C" fn get<P: Plugin>(
@@ -48,7 +48,7 @@ where
         };
 
         let mut writer = NoteNameWriter::from_raw(config);
-        p.main_thread().as_ref().get(index as usize, &mut writer);
+        p.main_thread().as_mut().get(index as usize, &mut writer);
         Ok(writer.is_set)
     })
     .unwrap_or(false)

--- a/extensions/src/note_ports/host.rs
+++ b/extensions/src/note_ports/host.rs
@@ -24,7 +24,7 @@ impl NotePortInfoBuffer {
 }
 
 impl PluginNotePorts {
-    pub fn count(&self, plugin: &PluginMainThreadHandle, is_input: bool) -> u32 {
+    pub fn count(&self, plugin: &mut PluginMainThreadHandle, is_input: bool) -> u32 {
         match self.0.count {
             None => 0,
             Some(count) => unsafe { count(plugin.as_raw(), is_input) },
@@ -33,7 +33,7 @@ impl PluginNotePorts {
 
     pub fn get<'b>(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         index: u32,
         is_input: bool,
         buffer: &'b mut NotePortInfoBuffer,

--- a/extensions/src/note_ports/plugin.rs
+++ b/extensions/src/note_ports/plugin.rs
@@ -44,8 +44,8 @@ impl<'a> NotePortInfoWriter<'a> {
 }
 
 pub trait PluginNotePortsImpl {
-    fn count(&self, is_input: bool) -> u32;
-    fn get(&self, is_input: bool, index: u32, writer: &mut NotePortInfoWriter);
+    fn count(&mut self, is_input: bool) -> u32;
+    fn get(&mut self, is_input: bool, index: u32, writer: &mut NotePortInfoWriter);
 }
 
 impl<P: Plugin> ExtensionImplementation<P> for PluginNotePorts
@@ -65,7 +65,7 @@ unsafe extern "C" fn count<P: Plugin>(plugin: *const clap_plugin, is_input: bool
 where
     for<'a> P::MainThread<'a>: PluginNotePortsImpl,
 {
-    PluginWrapper::<P>::handle(plugin, |p| Ok(p.main_thread().as_ref().count(is_input)))
+    PluginWrapper::<P>::handle(plugin, |p| Ok(p.main_thread().as_mut().count(is_input)))
         .unwrap_or(0)
 }
 
@@ -84,7 +84,7 @@ where
         };
 
         let mut writer = NotePortInfoWriter::from_raw(info);
-        p.main_thread().as_ref().get(is_input, index, &mut writer);
+        p.main_thread().as_mut().get(is_input, index, &mut writer);
         Ok(writer.is_set)
     })
     .unwrap_or(false)

--- a/extensions/src/params/host.rs
+++ b/extensions/src/params/host.rs
@@ -6,7 +6,7 @@ use std::ffi::CStr;
 use std::mem::MaybeUninit;
 
 impl PluginParams {
-    pub fn count(&self, plugin: &PluginMainThreadHandle) -> u32 {
+    pub fn count(&self, plugin: &mut PluginMainThreadHandle) -> u32 {
         match self.0.count {
             None => 0,
             Some(count) => unsafe { count(plugin.as_raw()) },
@@ -15,7 +15,7 @@ impl PluginParams {
 
     pub fn get_info<'b>(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         param_index: u32,
         info: &'b mut MaybeUninit<ParamInfo>,
     ) -> Option<&'b mut ParamInfo> {
@@ -32,7 +32,7 @@ impl PluginParams {
 
     pub fn get_value<H: Host>(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         param_id: u32,
     ) -> Option<f64> {
         let mut value = MaybeUninit::uninit();
@@ -47,7 +47,7 @@ impl PluginParams {
 
     pub fn value_to_text<'b, H: Host>(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         param_id: u32,
         value: f64,
         buffer: &'b mut [MaybeUninit<u8>],
@@ -75,7 +75,7 @@ impl PluginParams {
 
     pub fn text_to_value<H: Host>(
         &self,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
         param_id: u32,
         display: &CStr,
     ) -> Option<f64> {

--- a/host/examples/cpal/src/host/audio/config.rs
+++ b/host/examples/cpal/src/host/audio/config.rs
@@ -43,8 +43,8 @@ impl FullAudioConfig {
     ) -> Result<Self, Box<dyn Error>> {
         let best_cpal_configs = list_device_configs_ordered(device)?;
 
-        let input_ports = get_config_from_ports(&instance.main_thread_plugin_data(), true);
-        let output_ports = get_config_from_ports(&instance.main_thread_plugin_data(), false);
+        let input_ports = get_config_from_ports(&mut instance.main_thread_plugin_data(), true);
+        let output_ports = get_config_from_ports(&mut instance.main_thread_plugin_data(), false);
 
         Ok(find_matching_output_config(
             &best_cpal_configs,
@@ -277,7 +277,7 @@ fn sample_type_preference(sample_type: SampleFormat) -> u8 {
 ///
 /// This can query either the input ports or the output ports.
 pub fn get_config_from_ports(
-    plugin: &PluginMainThreadHandle,
+    plugin: &mut PluginMainThreadHandle,
     is_input: bool,
 ) -> PluginAudioPortsConfig {
     let Some(ports) = plugin.shared().get_extension::<PluginAudioPorts>() else {

--- a/host/examples/cpal/src/host/audio/midi.rs
+++ b/host/examples/cpal/src/host/audio/midi.rs
@@ -230,13 +230,13 @@ fn push_midi_to_buffer(
 ///
 /// This returns `None` if it couldn't find one.
 fn find_main_note_port_index(instance: &mut PluginInstance<CpalHost>) -> Option<(u32, bool)> {
-    let handle = instance.main_thread_plugin_data();
+    let mut handle = instance.main_thread_plugin_data();
     let plugin_note_ports = handle.shared().get_extension::<PluginNotePorts>()?;
 
     let mut buffer = NotePortInfoBuffer::new();
-    let ports_count = plugin_note_ports.count(&handle, true);
+    let ports_count = plugin_note_ports.count(&mut handle, true);
     for i in 0..ports_count {
-        let Some(port_info) = plugin_note_ports.get(&handle, i, true, &mut buffer) else {
+        let Some(port_info) = plugin_note_ports.get(&mut handle, i, true, &mut buffer) else {
             continue;
         };
 

--- a/host/examples/cpal/src/host/gui.rs
+++ b/host/examples/cpal/src/host/gui.rs
@@ -110,7 +110,7 @@ impl<'a> Gui<'a> {
     /// only figures out if that is okay for the plugin, and whether or not is supports embedding.
     fn negotiate_configuration(
         gui: &'a PluginGui,
-        plugin: &PluginMainThreadHandle,
+        plugin: &mut PluginMainThreadHandle,
     ) -> Option<GuiConfiguration<'static>> {
         // This implementation only supports the default: Win32 on Windows, Cocoa on MacOS, X11 on Unix
         // We completely ignore the plugin's preference here: it's platform-default or nothing.

--- a/plugin/examples/gain/src/lib.rs
+++ b/plugin/examples/gain/src/lib.rs
@@ -101,11 +101,11 @@ impl<'a> PluginAudioProcessorParams for GainPluginAudioProcessor<'a> {
 }
 
 impl<'a> PluginAudioPortsImpl for GainPluginMainThread<'a> {
-    fn count(&self, _is_input: bool) -> u32 {
+    fn count(&mut self, _is_input: bool) -> u32 {
         1
     }
 
-    fn get(&self, _is_input: bool, index: u32, writer: &mut AudioPortInfoWriter) {
+    fn get(&mut self, _is_input: bool, index: u32, writer: &mut AudioPortInfoWriter) {
         if index == 0 {
             writer.set(&AudioPortInfoData {
                 id: 0,
@@ -151,11 +151,11 @@ impl<'a> PluginMainThread<'a, GainPluginShared<'a>> for GainPluginMainThread<'a>
 }
 
 impl<'a> PluginMainThreadParams for GainPluginMainThread<'a> {
-    fn count(&self) -> u32 {
+    fn count(&mut self) -> u32 {
         1
     }
 
-    fn get_info(&self, param_index: u32, info: &mut ParamInfoWriter) {
+    fn get_info(&mut self, param_index: u32, info: &mut ParamInfoWriter) {
         if param_index > 0 {
             return;
         }
@@ -172,7 +172,7 @@ impl<'a> PluginMainThreadParams for GainPluginMainThread<'a> {
         })
     }
 
-    fn get_value(&self, param_id: u32) -> Option<f64> {
+    fn get_value(&mut self, param_id: u32) -> Option<f64> {
         if param_id == 0 {
             Some(self.rusting as f64)
         } else {
@@ -181,7 +181,7 @@ impl<'a> PluginMainThreadParams for GainPluginMainThread<'a> {
     }
 
     fn value_to_text(
-        &self,
+        &mut self,
         param_id: u32,
         value: f64,
         writer: &mut ParamDisplayWriter,
@@ -196,7 +196,7 @@ impl<'a> PluginMainThreadParams for GainPluginMainThread<'a> {
         }
     }
 
-    fn text_to_value(&self, _param_id: u32, _text: &str) -> Option<f64> {
+    fn text_to_value(&mut self, _param_id: u32, _text: &str) -> Option<f64> {
         None
     }
 

--- a/plugin/examples/gain/tests/test_gain.rs
+++ b/plugin/examples/gain/tests/test_gain.rs
@@ -48,17 +48,17 @@ pub fn it_works() {
 
     let plugin = host.plugin_mut();
 
-    let plugin_main_thread = plugin.main_thread_plugin_data();
+    let mut plugin_main_thread = plugin.main_thread_plugin_data();
     let ports_ext = plugin_main_thread
         .shared()
         .get_extension::<PluginAudioPorts>()
         .unwrap();
-    assert_eq!(1, ports_ext.count(&plugin_main_thread, true));
-    assert_eq!(1, ports_ext.count(&plugin_main_thread, false));
+    assert_eq!(1, ports_ext.count(&mut plugin_main_thread, true));
+    assert_eq!(1, ports_ext.count(&mut plugin_main_thread, false));
 
     let mut buf = AudioPortInfoBuffer::new();
     let info = ports_ext
-        .get(&plugin_main_thread, 0, false, &mut buf)
+        .get(&mut plugin_main_thread, 0, false, &mut buf)
         .unwrap();
 
     assert_eq!(info.id, 0);

--- a/plugin/examples/polysynth/src/lib.rs
+++ b/plugin/examples/polysynth/src/lib.rs
@@ -138,7 +138,7 @@ impl<'a> PluginAudioProcessor<'a, PolySynthPluginShared, PolySynthPluginMainThre
 }
 
 impl<'a> PluginAudioPortsImpl for PolySynthPluginMainThread<'a> {
-    fn count(&self, is_input: bool) -> u32 {
+    fn count(&mut self, is_input: bool) -> u32 {
         if is_input {
             0
         } else {
@@ -146,7 +146,7 @@ impl<'a> PluginAudioPortsImpl for PolySynthPluginMainThread<'a> {
         }
     }
 
-    fn get(&self, is_input: bool, index: u32, writer: &mut AudioPortInfoWriter) {
+    fn get(&mut self, is_input: bool, index: u32, writer: &mut AudioPortInfoWriter) {
         if !is_input && index == 0 {
             writer.set(&AudioPortInfoData {
                 id: 1,
@@ -161,7 +161,7 @@ impl<'a> PluginAudioPortsImpl for PolySynthPluginMainThread<'a> {
 }
 
 impl<'a> PluginNotePortsImpl for PolySynthPluginMainThread<'a> {
-    fn count(&self, is_input: bool) -> u32 {
+    fn count(&mut self, is_input: bool) -> u32 {
         if is_input {
             1
         } else {
@@ -169,7 +169,7 @@ impl<'a> PluginNotePortsImpl for PolySynthPluginMainThread<'a> {
         }
     }
 
-    fn get(&self, is_input: bool, index: u32, writer: &mut NotePortInfoWriter) {
+    fn get(&mut self, is_input: bool, index: u32, writer: &mut NotePortInfoWriter) {
         if is_input && index == 0 {
             writer.set(&NotePortInfoData {
                 id: 1,

--- a/plugin/examples/polysynth/src/params.rs
+++ b/plugin/examples/polysynth/src/params.rs
@@ -85,11 +85,11 @@ impl<'a> PluginStateImpl for PolySynthPluginMainThread<'a> {
 }
 
 impl<'a> PluginMainThreadParams for PolySynthPluginMainThread<'a> {
-    fn count(&self) -> u32 {
+    fn count(&mut self) -> u32 {
         1
     }
 
-    fn get_info(&self, param_index: u32, info: &mut ParamInfoWriter) {
+    fn get_info(&mut self, param_index: u32, info: &mut ParamInfoWriter) {
         if param_index != 0 {
             return;
         }
@@ -105,7 +105,7 @@ impl<'a> PluginMainThreadParams for PolySynthPluginMainThread<'a> {
         })
     }
 
-    fn get_value(&self, param_id: u32) -> Option<f64> {
+    fn get_value(&mut self, param_id: u32) -> Option<f64> {
         if param_id == 1 {
             Some(self.shared.params.get_volume() as f64)
         } else {
@@ -114,7 +114,7 @@ impl<'a> PluginMainThreadParams for PolySynthPluginMainThread<'a> {
     }
 
     fn value_to_text(
-        &self,
+        &mut self,
         param_id: u32,
         value: f64,
         writer: &mut ParamDisplayWriter,
@@ -126,7 +126,7 @@ impl<'a> PluginMainThreadParams for PolySynthPluginMainThread<'a> {
         }
     }
 
-    fn text_to_value(&self, param_id: u32, text: &str) -> Option<f64> {
+    fn text_to_value(&mut self, param_id: u32, text: &str) -> Option<f64> {
         if param_id == 1 {
             let text = text.strip_suffix('%').unwrap_or(text).trim();
             let percentage: f64 = text.parse().ok()?;

--- a/plugin/src/process/audio/input.rs
+++ b/plugin/src/process/audio/input.rs
@@ -4,7 +4,7 @@ use clack_common::process::ConstantMask;
 use clap_sys::audio_buffer::clap_audio_buffer;
 use std::slice::Iter;
 
-/// An iterator of all of the available [`InputPort`]s from an [`Audio`] struct.
+/// An iterator of all the available [`InputPort`]s from an [`Audio`] struct.
 pub struct InputPortsIter<'a> {
     inputs: Iter<'a, clap_audio_buffer>,
     frames_count: u32,
@@ -67,7 +67,7 @@ impl<'a> InputPort<'a> {
     /// # Errors
     ///
     /// This method returns a [`BufferError::InvalidChannelBuffer`] if the host provided neither
-    /// [`f32`] or [`f64`] buffer type, which is invalid per the CLAP specification.
+    /// [`f32`] nor [`f64`] buffer type, which is invalid per the CLAP specification.
     ///
     /// # Example
     ///
@@ -140,7 +140,7 @@ impl<'a> InputPort<'a> {
 #[derive(Copy, Clone)]
 pub struct InputChannels<'a, S> {
     frames_count: u32,
-    data: &'a [*const S],
+    data: &'a [*mut S],
 }
 
 impl<'a, S> InputChannels<'a, S> {
@@ -157,7 +157,7 @@ impl<'a, S> InputChannels<'a, S> {
     /// In CLAP's API, hosts provide a port's audio data as an array of raw pointers, each of which points
     /// to the start of a sample array of type `S` and of [`frames_count`](Self::frames_count) length.
     #[inline]
-    pub fn raw_data(&self) -> &'a [*const S] {
+    pub fn raw_data(&self) -> &'a [*mut S] {
         self.data
     }
 
@@ -180,7 +180,7 @@ impl<'a, S> InputChannels<'a, S> {
         }
     }
 
-    /// Gets an iterator over all of the port's channels' sample buffers.
+    /// Gets an iterator over all the port's channels' sample buffers.
     #[inline]
     pub fn iter(&self) -> InputChannelsIter<'a, S> {
         InputChannelsIter {
@@ -213,7 +213,7 @@ impl<'a, T> IntoIterator for &'a InputChannels<'a, T> {
 /// An iterator over all of an [`InputPort`]'s channels' sample buffers.
 pub struct InputChannelsIter<'a, T> {
     // TODO: hide these with new() function
-    pub(crate) data: Iter<'a, *const T>,
+    pub(crate) data: Iter<'a, *mut T>,
     pub(crate) frames_count: u32,
 }
 

--- a/plugin/src/process/audio/output.rs
+++ b/plugin/src/process/audio/output.rs
@@ -145,7 +145,7 @@ impl<'a> OutputPort<'a> {
 /// [`OutputPort::channels`].
 pub struct OutputChannels<'a, S> {
     pub(crate) frames_count: u32,
-    pub(crate) data: &'a mut [*const S],
+    pub(crate) data: &'a mut [*mut S],
 }
 
 impl<'a, S> OutputChannels<'a, S> {
@@ -162,7 +162,7 @@ impl<'a, S> OutputChannels<'a, S> {
     /// In CLAP's API, hosts provide a port's audio data as an array of raw pointers, each of which points
     /// to the start of a sample array of type `S` and of [`frames_count`](Self::frames_count) length.
     #[inline]
-    pub fn raw_data(&self) -> &[*const S] {
+    pub fn raw_data(&self) -> &[*mut S] {
         self.data
     }
 
@@ -284,7 +284,7 @@ impl<'a, T> IntoIterator for OutputChannels<'a, T> {
 
 /// An iterator over all of an [`OutputPort`]'s channels' writable sample buffers.
 pub struct OutputChannelsIter<'a, T> {
-    data: IterMut<'a, *const T>,
+    data: IterMut<'a, *mut T>,
     frames_count: u32,
 }
 

--- a/plugin/src/process/audio/pair.rs
+++ b/plugin/src/process/audio/pair.rs
@@ -178,8 +178,8 @@ impl<'a> PortPair<'a> {
 /// The sample type `S` is always going to be either [`f32`] or [`f64`], as returned by
 /// [`PortPair::channels`].
 pub struct PairedChannels<'a, S> {
-    input_data: &'a [*const S],
-    output_data: &'a mut [*const S],
+    input_data: &'a [*mut S],
+    output_data: &'a mut [*mut S],
     frames_count: u32,
 }
 
@@ -229,7 +229,7 @@ impl<'a, S> PairedChannels<'a, S> {
             .map(|ptr| unsafe { core::slice::from_raw_parts(*ptr, self.frames_count as usize) });
 
         let output = self.output_data.get(index).map(|ptr| unsafe {
-            core::slice::from_raw_parts_mut(*ptr as *mut _, self.frames_count as usize)
+            core::slice::from_raw_parts_mut(*ptr, self.frames_count as usize)
         });
 
         ChannelPair::from_optional_io(input, output)
@@ -262,8 +262,8 @@ impl<'a, S> IntoIterator for PairedChannels<'a, S> {
 
 /// An iterator over all of a [`PortPair`]'s [`ChannelPair`]s.
 pub struct PairedChannelsIter<'a, S> {
-    input_iter: Iter<'a, *const S>,
-    output_iter: IterMut<'a, *const S>,
+    input_iter: Iter<'a, *mut S>,
+    output_iter: IterMut<'a, *mut S>,
     frames_count: u32,
 }
 


### PR DESCRIPTION
This PR introduces some breaking changes on both the Plugin and Host side to better match the CLAP spec's exclusivity guarantees when calling `[main-thread]` methods.

Some plugin methods (such as `PluginAudioPorts::count` for instance) currently only require `&self` because it "made sense" from a Rustacean point of view since it's unlikely that those methods would change state. However the CLAP spec does allow them to do so, which prompts this change.

This also makes some extra changes and additions:

* Add methods to the `Window` type to allow accessing the raw handles without using the `raw-window-handle` crate.
* Make `GuiApiType::default_for_current_platform` a `const fn`.
* Make the `InputChannels` and `OutputChannels`'s `raw_data` method return `&[*mut T]` instead of `&[*const T]`.