### PR TITLE
Add the ability to use the GUI extension with `raw-window-handle` v0.5, v0.6, or neither.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ selfie = { git = 'https://github.com/prokopyl/selfie', rev = '726013fc94835b6f24
 
 bitflags = "1.3.2"
 libloading = "0.8.1"
-raw-window-handle = "0.5.2"
+raw-window-handle_05 = { package = "raw-window-handle", version = "0.5.2" }
+raw-window-handle_06 = { package = "raw-window-handle", version = "0.6.0" }
 stable_deref_trait = "1.2.0"

--- a/extensions/Cargo.toml
+++ b/extensions/Cargo.toml
@@ -14,7 +14,8 @@ clack-common = { workspace = true }
 clap-sys = { workspace = true }
 
 bitflags = { workspace = true }
-raw-window-handle = { workspace = true, optional = true }
+raw-window-handle_05 = { workspace = true, optional = true }
+raw-window-handle_06 = { workspace = true, optional = true }
 
 [features]
 all-extensions = [
@@ -38,7 +39,7 @@ all-extensions = [
 audio-ports = []
 audio-ports-config = []
 event-registry = []
-gui = ["raw-window-handle"]
+gui = []
 latency = []
 log = []
 note-name = []

--- a/extensions/src/__doc_utils.rs
+++ b/extensions/src/__doc_utils.rs
@@ -2,6 +2,7 @@ use clack_host::prelude::*;
 
 mod diva_stub {
     #[cfg(test)]
+    #[allow(clippy::items_after_test_module)] // This is not really a test module
     mod clack_extensions {
         pub use crate::*;
     }
@@ -10,7 +11,6 @@ mod diva_stub {
 
     use clack_common::stream::{InputStream, OutputStream};
     use clack_plugin::clack_entry;
-    use clack_plugin::plugin::descriptor::{PluginDescriptor, StaticPluginDescriptor};
     use clack_plugin::prelude::*;
     use std::ffi::CStr;
     use std::io::{Read, Write};

--- a/extensions/src/gui.rs
+++ b/extensions/src/gui.rs
@@ -346,7 +346,7 @@ impl<'a> GuiApiType<'a> {
     pub const WAYLAND: GuiApiType<'static> =
         GuiApiType(unsafe { CStr::from_bytes_with_nul_unchecked(b"wayland\0") });
 
-    /// Whether or not this API type can provide a [`RawWindowHandle`](raw_window_handle::RawWindowHandle).
+    /// Whether this API type can provide a `RawWindowHandle`.
     pub fn can_provide_raw_window_handle(&self) -> bool {
         self == &Self::WIN32 || self == &Self::COCOA || self == &Self::X11
     }

--- a/extensions/src/gui.rs
+++ b/extensions/src/gui.rs
@@ -2,12 +2,26 @@
 //!
 //! There are two available approaches, either:
 //!
-//! * The plugin the plugin creates a window and embeds it into the host's window. This is often the
+//! * The plugin creates a window and embeds it into the host's window. This is often the
 //!   preferred option, as it gives more control to the host, and feels more integrated.
 //!
 //! * The plugin creates an independent, floating window. This option should always be supported, at
 //!   least as a fallback, in case window embedding is not available, which can be the case due to
 //!   technical limitations.
+//!
+//! ## Compatibility with the `raw-window-handle` crate
+//!
+//! The [`Window`] type has optional support for the traits from the `raw-window-handle` crate:
+//!
+//! * By default, this module has no dependency on the `raw-window-handle` crate;
+//! * If the `raw_window_handle_05` feature is enabled, this module will depend on
+//!   `raw-window-handle` version `0.5`. The [`Window`] type will implement the `HasRawWindowHandle`
+//!   trait, and the [`Window::from_raw_window`] and [`Window::from_raw_window_handle`] methods
+//!   will become available.
+//! * If the `raw_window_handle_06` feature is enabled, this module will depend on
+//!   `raw-window-handle` version `0.6`. The [`Window`] type will implement the `HasWindowHandle`
+//!   trait, and the [`Window::from_window`] and [`Window::from_window_handle`] methods
+//!   will become available.
 //!
 //! ## Opening a Plugin GUI
 //!

--- a/extensions/src/gui/host.rs
+++ b/extensions/src/gui/host.rs
@@ -180,7 +180,7 @@ impl PluginGui {
     pub fn set_parent(
         &self,
         plugin: &mut PluginMainThreadHandle,
-        window: &Window,
+        window: Window,
     ) -> Result<(), GuiError> {
         let success = unsafe {
             self.inner.set_parent.ok_or(GuiError::SetParentError)?(plugin.as_raw(), window.as_raw())

--- a/extensions/src/gui/plugin.rs
+++ b/extensions/src/gui/plugin.rs
@@ -1,7 +1,5 @@
 use super::*;
 use clack_plugin::extensions::prelude::*;
-use clap_sys::ext::gui::{clap_gui_resize_hints, clap_plugin_gui, clap_window};
-use std::ffi::CStr;
 use std::os::raw::c_char;
 
 impl HostGui {

--- a/extensions/src/gui/plugin.rs
+++ b/extensions/src/gui/plugin.rs
@@ -98,7 +98,7 @@ impl HostGui {
 ///    or [get_size][Self::get_size] to get initial size
 /// 4. [set_parent][Self::set_parent]
 #[allow(unused)]
-pub trait PluginGuiImpl {
+pub trait PluginGuiImpl<'a> {
     /// Indicate whether a particular API is supported.
     #[allow(clippy::wrong_self_convention)] // To match the CLAP naming
     fn is_api_supported(&mut self, configuration: GuiConfiguration) -> bool;
@@ -155,12 +155,12 @@ pub trait PluginGuiImpl {
     fn set_size(&mut self, size: GuiSize) -> Result<(), GuiError>;
 
     /// Embed UI into the given parent window
-    fn set_parent(&mut self, window: Window) -> Result<(), GuiError>;
+    fn set_parent(&mut self, window: Window<'a>) -> Result<(), GuiError>;
 
     /// Receive instruction to stay above the given window
     ///
     /// Only applies to floating windows.
-    fn set_transient(&mut self, window: Window) -> Result<(), GuiError>;
+    fn set_transient(&mut self, window: Window<'a>) -> Result<(), GuiError>;
 
     /// Receive a suggested window title from the host
     ///
@@ -178,7 +178,7 @@ pub trait PluginGuiImpl {
 
 impl<P: Plugin> ExtensionImplementation<P> for PluginGui
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     const IMPLEMENTATION: &'static Self = &PluginGui {
         inner: clap_plugin_gui {
@@ -207,7 +207,7 @@ unsafe extern "C" fn is_api_supported<P: Plugin>(
     is_floating: bool,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         Ok(plugin
@@ -227,7 +227,7 @@ unsafe extern "C" fn get_preferred_api<P: Plugin>(
     floating: *mut bool,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         if api.is_null() || floating.is_null() {
@@ -256,7 +256,7 @@ unsafe extern "C" fn create<P: Plugin>(
     is_floating: bool,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         Ok(plugin
@@ -273,7 +273,7 @@ where
 
 unsafe extern "C" fn destroy<P: Plugin>(plugin: *const clap_plugin)
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         plugin.main_thread().as_mut().destroy();
@@ -283,7 +283,7 @@ where
 
 unsafe extern "C" fn set_scale<P: Plugin>(plugin: *const clap_plugin, scale: f64) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         Ok(plugin.main_thread().as_mut().set_scale(scale).is_ok())
@@ -297,7 +297,7 @@ unsafe extern "C" fn get_size<P: Plugin>(
     height: *mut u32,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         if let Some(size) = plugin.main_thread().as_mut().get_size() {
@@ -315,7 +315,7 @@ where
 
 unsafe extern "C" fn can_resize<P: Plugin>(plugin: *const clap_plugin) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         Ok(plugin.main_thread().as_mut().can_resize())
@@ -328,7 +328,7 @@ unsafe extern "C" fn get_resize_hints<P: Plugin>(
     hints: *mut clap_gui_resize_hints,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         if let Some(plugin_hints) = plugin.main_thread().as_mut().get_resize_hints() {
@@ -355,7 +355,7 @@ unsafe extern "C" fn adjust_size<P: Plugin>(
     height_adj: *mut u32,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     if width_adj.is_null() || height_adj.is_null() {
         return false;
@@ -388,7 +388,7 @@ unsafe extern "C" fn set_size<P: Plugin>(
     height: u32,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         let size = GuiSize { width, height };
@@ -402,7 +402,7 @@ unsafe extern "C" fn set_parent<P: Plugin>(
     window: *const clap_window,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         let window = window
@@ -423,7 +423,7 @@ unsafe extern "C" fn set_transient<P: Plugin>(
     window: *const clap_window,
 ) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         let window = window
@@ -441,7 +441,7 @@ where
 
 unsafe extern "C" fn suggest_title<P: Plugin>(plugin: *const clap_plugin, title: *const c_char)
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         let title = CStr::from_ptr(title)
@@ -456,7 +456,7 @@ where
 
 unsafe extern "C" fn show<P: Plugin>(plugin: *const clap_plugin) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         Ok(plugin.main_thread().as_mut().show().is_ok())
@@ -466,7 +466,7 @@ where
 
 unsafe extern "C" fn hide<P: Plugin>(plugin: *const clap_plugin) -> bool
 where
-    for<'a> P::MainThread<'a>: PluginGuiImpl,
+    for<'a> P::MainThread<'a>: PluginGuiImpl<'a>,
 {
     PluginWrapper::<P>::handle(plugin, |plugin| {
         Ok(plugin.main_thread().as_mut().hide().is_ok())

--- a/extensions/src/gui/window.rs
+++ b/extensions/src/gui/window.rs
@@ -1,20 +1,23 @@
 use crate::gui::GuiApiType;
 use clap_sys::ext::gui::*;
 use core::ffi::{c_ulong, c_void, CStr};
-use raw_window_handle::{
-    AppKitWindowHandle, HasRawWindowHandle, RawWindowHandle, Win32WindowHandle, XlibWindowHandle,
-};
+use std::marker::PhantomData;
 
-/// A host-provided parent window.
-pub struct Window {
+/// A handle to a host-provided parent window.
+#[derive(Copy, Clone)]
+pub struct Window<'a> {
     raw: clap_window,
+    _lifetime: PhantomData<&'a c_void>,
 }
 
-impl Window {
+impl<'a> Window<'a> {
     #[cfg(feature = "clack-plugin")]
     #[inline]
     pub(crate) unsafe fn from_raw(raw: clap_window) -> Self {
-        Self { raw }
+        Self {
+            raw,
+            _lifetime: PhantomData,
+        }
     }
 
     /// Returns the windowing API that is used to handle this window.
@@ -23,7 +26,7 @@ impl Window {
         unsafe { GuiApiType(CStr::from_ptr(self.raw.api)) }
     }
 
-    /// Returns the window as a reference to the C-FFI compatible CLAP struct.
+    /// Returns the window handle as a reference to the C-FFI compatible CLAP struct.
     #[inline]
     pub fn as_raw(&self) -> &clap_window {
         &self.raw
@@ -38,6 +41,25 @@ impl Window {
         unsafe { self.raw.specific.ptr }
     }
 
+    /// Creates a [`Window`] handle from a raw `generic_pointer` to a window of a custom `api_type`.
+    ///
+    /// # Safety
+    ///
+    /// Users of this method must ensure the object `generic_pointer` points to is valid for the
+    /// entire duration of `'a`.
+    #[inline]
+    pub unsafe fn from_generic_ptr(api_type: GuiApiType<'a>, generic_pointer: *mut c_void) -> Self {
+        Self {
+            raw: clap_window {
+                api: api_type.0.as_ptr(),
+                specific: clap_window_handle {
+                    ptr: generic_pointer,
+                },
+            },
+            _lifetime: PhantomData,
+        }
+    }
+
     /// Returns the window's handle as a Win32 `HWND`, if this is a Win32 window.
     /// Otherwise, this returns `None`.
     pub fn as_win32_hwnd(&self) -> Option<*mut c_void> {
@@ -46,6 +68,23 @@ impl Window {
             unsafe { Some(self.raw.specific.win32) }
         } else {
             None
+        }
+    }
+
+    /// Creates a [`Window`] handle from a Win32 `HWND`.
+    ///
+    /// # Safety
+    ///
+    /// Users of this method must ensure the given `hwnd` is valid for the
+    /// entire duration of `'a`.
+    #[inline]
+    pub unsafe fn from_win32_hwnd(hwnd: *mut c_void) -> Self {
+        Self {
+            raw: clap_window {
+                api: GuiApiType::WIN32.0.as_ptr(),
+                specific: clap_window_handle { win32: hwnd },
+            },
+            _lifetime: PhantomData,
         }
     }
 
@@ -60,6 +99,23 @@ impl Window {
         }
     }
 
+    /// Creates a [`Window`] handle from a Cocoa `NSView`.
+    ///
+    /// # Safety
+    ///
+    /// Users of this method must ensure the given `nsview` is valid for the
+    /// entire duration of `'a`.
+    #[inline]
+    pub unsafe fn from_cocoa_nsview(nsview: *mut c_void) -> Self {
+        Self {
+            raw: clap_window {
+                api: GuiApiType::COCOA.0.as_ptr(),
+                specific: clap_window_handle { cocoa: nsview },
+            },
+            _lifetime: PhantomData,
+        }
+    }
+
     /// Returns the window's handle as an X11 window handle, if this is an X11 window.
     /// Otherwise, this returns `None`.
     pub fn as_x11_handle(&self) -> Option<c_ulong> {
@@ -71,62 +127,85 @@ impl Window {
         }
     }
 
-    /// Creates a [`Window`] from any window object implementing [`HasRawWindowHandle`].
+    /// Creates a [`Window`] handle from an X11 window handle.
     ///
-    /// This returns [`None`] if the given window handle isn't backed by the default supported APIs.
+    /// # Safety
+    ///
+    /// Users of this method must ensure the given `handle` is valid for the
+    /// entire duration of `'a`.
     #[inline]
-    pub fn from_window<W: HasRawWindowHandle>(window: &W) -> Option<Self> {
-        Self::from_raw_window_handle(window.raw_window_handle())
-    }
-
-    /// Creates a [`Window`] from a [`RawWindowHandle`].
-    ///
-    /// This returns [`None`] if the given window handle isn't backed by the default supported APIs.
-    pub fn from_raw_window_handle(handle: RawWindowHandle) -> Option<Self> {
-        match handle {
-            RawWindowHandle::Xlib(handle) => Some(Self {
-                raw: clap_window {
-                    api: GuiApiType::X11.0.as_ptr(),
-                    specific: clap_window_handle { x11: handle.window },
-                },
-            }),
-            RawWindowHandle::Win32(handle) => Some(Self {
-                raw: clap_window {
-                    api: GuiApiType::WIN32.0.as_ptr(),
-                    specific: clap_window_handle { win32: handle.hwnd },
-                },
-            }),
-            RawWindowHandle::AppKit(handle) => Some(Self {
-                raw: clap_window {
-                    api: GuiApiType::COCOA.0.as_ptr(),
-                    specific: clap_window_handle {
-                        cocoa: handle.ns_view,
-                    },
-                },
-            }),
-            _ => None,
+    pub unsafe fn from_x11_handle(handle: c_ulong) -> Self {
+        Self {
+            raw: clap_window {
+                api: GuiApiType::X11.0.as_ptr(),
+                specific: clap_window_handle { x11: handle },
+            },
+            _lifetime: PhantomData,
         }
     }
 }
 
-unsafe impl HasRawWindowHandle for Window {
-    fn raw_window_handle(&self) -> RawWindowHandle {
-        let api_type = self.api_type();
+#[cfg(feature = "raw-window-handle_05")]
+const _: () = {
+    use raw_window_handle_05::{
+        AppKitWindowHandle, HasRawWindowHandle, HasWindowHandle, RawWindowHandle,
+        Win32WindowHandle, WindowHandle, XlibWindowHandle,
+    };
 
-        if api_type == GuiApiType::WIN32 {
-            let mut handle = Win32WindowHandle::empty();
-            handle.hwnd = unsafe { self.raw.specific.win32 };
-            RawWindowHandle::Win32(handle)
-        } else if api_type == GuiApiType::COCOA {
-            let mut handle = AppKitWindowHandle::empty();
-            handle.ns_view = unsafe { self.raw.specific.cocoa };
-            RawWindowHandle::AppKit(handle)
-        } else if api_type == GuiApiType::X11 {
-            let mut handle = XlibWindowHandle::empty();
-            handle.window = unsafe { self.raw.specific.x11 };
-            RawWindowHandle::Xlib(handle)
-        } else {
-            panic!("Unknown GUI API type: {api_type:?}")
+    impl<'a> TryFrom<WindowHandle<'a>> for Window<'a> {
+        type Error = ();
+
+        fn try_from(value: WindowHandle<'a>) -> Result<Self, Self::Error> {
+            match value.raw_window_handle() {
+                RawWindowHandle::Win32(handle) => unsafe { Ok(Self::from_win32_hwnd(handle.hwnd)) },
+                RawWindowHandle::AppKit(handle) => unsafe {
+                    Ok(Self::from_cocoa_nsview(handle.ns_view))
+                },
+                RawWindowHandle::Xlib(handle) => unsafe {
+                    Ok(Self::from_x11_handle(handle.window))
+                },
+                _ => Err(()),
+            }
         }
     }
-}
+
+    unsafe impl<'a> HasRawWindowHandle for Window<'a> {
+        fn raw_window_handle(&self) -> RawWindowHandle {
+            let api_type = self.api_type();
+
+            if api_type == GuiApiType::WIN32 {
+                let mut handle = Win32WindowHandle::empty();
+                handle.hwnd = unsafe { self.raw.specific.win32 };
+                RawWindowHandle::Win32(handle)
+            } else if api_type == GuiApiType::COCOA {
+                let mut handle = AppKitWindowHandle::empty();
+                handle.ns_view = unsafe { self.raw.specific.cocoa };
+                RawWindowHandle::AppKit(handle)
+            } else if api_type == GuiApiType::X11 {
+                let mut handle = XlibWindowHandle::empty();
+                handle.window = unsafe { self.raw.specific.x11 };
+                RawWindowHandle::Xlib(handle)
+            } else {
+                panic!("Unknown GUI API type: {api_type:?}")
+            }
+        }
+    }
+
+    impl<'a> Window<'a> {
+        /// Creates a [`Window`] from any window object implementing [`HasRawWindowHandle`].
+        ///
+        /// This returns [`None`] if the given window handle isn't backed by the default supported APIs.
+        #[inline]
+        pub fn from_window<W: HasWindowHandle>(window: &'a W) -> Option<Self> {
+            Self::from_window_handle(window.window_handle().ok()?)
+        }
+
+        /// Creates a [`Window`] from a [`WindowHandle`].
+        ///
+        /// This returns [`None`] if the given window handle isn't backed by the default supported APIs.
+        #[inline]
+        pub fn from_window_handle(handle: WindowHandle<'a>) -> Option<Self> {
+            handle.try_into().ok()
+        }
+    }
+};

--- a/extensions/src/gui/window.rs
+++ b/extensions/src/gui/window.rs
@@ -248,7 +248,7 @@ const _: () = {
         ///
         /// This returns [`None`] if the given window handle isn't backed by the default supported APIs.
         #[inline]
-        pub fn from_window_handle(handle: WindowHandle) -> Option<Self> {
+        pub fn from_window_handle(handle: WindowHandle<'a>) -> Option<Self> {
             match handle.as_raw() {
                 RawWindowHandle::Win32(handle) => unsafe {
                     Some(Self::from_win32_hwnd(handle.hwnd.get() as *mut _))

--- a/extensions/src/log.rs
+++ b/extensions/src/log.rs
@@ -81,7 +81,6 @@ unsafe impl Extension for HostLog {
 mod plugin {
     use super::*;
     use clack_plugin::host::HostHandle;
-    use std::ffi::CStr;
 
     impl HostLog {
         #[inline]

--- a/extensions/src/note_ports/plugin.rs
+++ b/extensions/src/note_ports/plugin.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::utils::write_to_array_buf;
 use clack_plugin::extensions::prelude::*;
-use std::marker::PhantomData;
 use std::mem::MaybeUninit;
 use std::ptr::addr_of_mut;
 

--- a/extensions/src/params/host.rs
+++ b/extensions/src/params/host.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::params::info::ParamInfo;
 use clack_common::events::io::{InputEvents, OutputEvents};
 use clack_host::extensions::prelude::*;
-use std::ffi::CStr;
 use std::mem::MaybeUninit;
 
 impl PluginParams {

--- a/extensions/src/posix_fd.rs
+++ b/extensions/src/posix_fd.rs
@@ -83,7 +83,6 @@ impl Display for FdError {
 mod host {
     use super::*;
     use clack_host::extensions::prelude::*;
-    use std::os::unix::prelude::RawFd;
 
     impl PluginPosixFd {
         /// A callback that gets called for every event on each registered File Descriptor.
@@ -176,7 +175,6 @@ pub use host::*;
 mod plugin {
     use super::*;
     use clack_plugin::extensions::prelude::*;
-    use std::os::unix::prelude::RawFd;
 
     impl HostPosixFd {
         /// Registers a given File Descriptor into the host's event reactor, for a given set of events.

--- a/extensions/src/thread_pool.rs
+++ b/extensions/src/thread_pool.rs
@@ -51,9 +51,7 @@ impl Error for ThreadPoolRequestError {}
 #[cfg(feature = "clack-plugin")]
 mod plugin {
     use super::*;
-
     use clack_plugin::extensions::prelude::*;
-    use clap_sys::ext::thread_pool::clap_plugin_thread_pool;
 
     /// Implementation of the Plugin-side of the Thread Pool extension.
     pub trait PluginThreadPoolImpl {

--- a/host/examples/cpal/Cargo.toml
+++ b/host/examples/cpal/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 clack-host = { workspace = true, features = ["default"] }
-clack-extensions = { workspace = true, features = ["clack-host", "audio-ports", "note-ports", "gui", "log", "params", "timer", "raw-window-handle_05"] }
+clack-extensions = { workspace = true, features = ["clack-host", "audio-ports", "note-ports", "gui", "log", "params", "timer", "raw-window-handle_06"] }
 cpal = "0.15.2"
 crossbeam-channel = "0.5.8"
 clap = { version = "4.3.0", features = ["derive"] }
@@ -16,5 +16,5 @@ midir = "0.9.1"
 rayon = "1.7.0"
 rtrb = "0.2.3"
 walkdir = "2.3.3"
-winit = { version = "0.28.6", default-features = false,  features = ["x11"] }
+winit = { version = "0.29.10", default-features = false,  features = ["rwh_06", "x11"] }
 wmidi = "4.0.6"

--- a/host/examples/cpal/Cargo.toml
+++ b/host/examples/cpal/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 clack-host = { workspace = true, features = ["default"] }
-clack-extensions = { workspace = true, features = ["clack-host", "audio-ports", "note-ports", "gui", "log", "params", "timer"] }
+clack-extensions = { workspace = true, features = ["clack-host", "audio-ports", "note-ports", "gui", "log", "params", "timer", "raw-window-handle_05"] }
 cpal = "0.15.2"
 crossbeam-channel = "0.5.8"
 clap = { version = "4.3.0", features = ["derive"] }

--- a/host/examples/cpal/src/host/gui.rs
+++ b/host/examples/cpal/src/host/gui.rs
@@ -214,7 +214,7 @@ impl<'a> Gui<'a> {
             .with_resizable(self.is_resizeable)
             .build(event_loop)?;
 
-        gui.set_parent(plugin, ClapWindow::from_raw_window(&window).unwrap())?;
+        gui.set_parent(plugin, ClapWindow::from_window(&window).unwrap())?;
         // Some plugins don't show anything until this is called, others return an error.
         let _ = gui.show(plugin);
         self.is_open = true;

--- a/host/examples/cpal/src/host/gui.rs
+++ b/host/examples/cpal/src/host/gui.rs
@@ -214,7 +214,7 @@ impl<'a> Gui<'a> {
             .with_resizable(self.is_resizeable)
             .build(event_loop)?;
 
-        gui.set_parent(plugin, &ClapWindow::from_window(&window).unwrap())?;
+        gui.set_parent(plugin, &ClapWindow::from_raw_window(&window).unwrap())?;
         // Some plugins don't show anything until this is called, others return an error.
         let _ = gui.show(plugin);
         self.is_open = true;

--- a/host/examples/cpal/src/host/gui.rs
+++ b/host/examples/cpal/src/host/gui.rs
@@ -214,7 +214,7 @@ impl<'a> Gui<'a> {
             .with_resizable(self.is_resizeable)
             .build(event_loop)?;
 
-        gui.set_parent(plugin, &ClapWindow::from_raw_window(&window).unwrap())?;
+        gui.set_parent(plugin, ClapWindow::from_raw_window(&window).unwrap())?;
         // Some plugins don't show anything until this is called, others return an error.
         let _ = gui.show(plugin);
         self.is_open = true;

--- a/host/src/bundle/diva_stub.rs
+++ b/host/src/bundle/diva_stub.rs
@@ -1,5 +1,4 @@
 use clack_plugin::clack_entry;
-use clack_plugin::plugin::descriptor::{PluginDescriptor, StaticPluginDescriptor};
 use clack_plugin::prelude::*;
 use std::ffi::CStr;
 

--- a/host/src/lib.rs
+++ b/host/src/lib.rs
@@ -285,7 +285,11 @@ pub mod prelude {
         plugin::PluginInstance,
         plugin::{PluginAudioProcessorHandle, PluginMainThreadHandle, PluginSharedHandle},
         process::{
-            audio_buffers::*, PluginAudioConfiguration, ProcessStatus, StoppedPluginAudioProcessor,
+            audio_buffers::{
+                AudioPortBuffer, AudioPortBufferType, AudioPorts, InputAudioBuffers, InputChannel,
+                OutputAudioBuffers, OutputAudioPortInfo,
+            },
+            PluginAudioConfiguration, ProcessStatus, StoppedPluginAudioProcessor,
         },
     };
 }

--- a/host/tests/drop.rs
+++ b/host/tests/drop.rs
@@ -1,4 +1,3 @@
-use clack_plugin::plugin::descriptor::{PluginDescriptor, StaticPluginDescriptor};
 use clack_plugin::prelude::*;
 use std::ffi::CStr;
 

--- a/host/tests/instance.rs
+++ b/host/tests/instance.rs
@@ -1,5 +1,4 @@
 use clack_host::factory::PluginFactory;
-use clack_plugin::plugin::descriptor::{PluginDescriptor, StaticPluginDescriptor};
 use clack_plugin::prelude::*;
 use std::ffi::CStr;
 

--- a/host/tests/shared-state.rs
+++ b/host/tests/shared-state.rs
@@ -1,6 +1,5 @@
 use clack_host::prelude::*;
 use clack_plugin::clack_entry;
-use clack_plugin::plugin::descriptor::{PluginDescriptor, StaticPluginDescriptor};
 use clack_plugin::prelude::*;
 use std::ffi::CStr;
 use std::sync::OnceLock;

--- a/plugin/examples/gain/src/lib.rs
+++ b/plugin/examples/gain/src/lib.rs
@@ -11,8 +11,6 @@ use clack_extensions::audio_ports::{
     AudioPortFlags, AudioPortInfoData, AudioPortInfoWriter, AudioPortType, PluginAudioPorts,
     PluginAudioPortsImpl,
 };
-use clack_plugin::plugin::descriptor::StaticPluginDescriptor;
-use clack_plugin::process::audio::ChannelPair;
 use clack_plugin::utils::Cookie;
 
 pub struct GainPlugin;

--- a/plugin/src/entry.rs
+++ b/plugin/src/entry.rs
@@ -38,7 +38,7 @@ pub use single::SinglePluginEntry;
 /// A prelude that's helpful for implementing custom [`Entry`] and [`PluginFactory`](crate::factory::plugin::PluginFactory) types.
 pub mod prelude {
     pub use crate::{
-        entry::*,
+        entry::{Entry, EntryDescriptor, EntryFactories, EntryLoadError, SinglePluginEntry},
         factory::{
             plugin::{PluginFactory, PluginFactoryWrapper},
             Factory,


### PR DESCRIPTION
**This PR contains breaking changes to the `clack_extentions` GUI module!**

This PR makes the `raw-window-handle` dependency optional, and allows users to choose to depend on version `0.5`, or on version `0.6` depending on their needs. This is done using two new Cargo features: `raw-window-handle_05`, and `raw-window-handle_06`.

In doing so, the following changes were also made:

* Made the `Window` type `Copy` (as it's essentially just a couple of pointers), but added a lifetime parameter to represent the lifetime of the pointers inside.
* Changed the naming conventions of `Window::from_window` and `Window::from_raw_window_handle`:
  *  `Window::from_window` and `Window::from_window_handle` are the two methods exposed by `raw-window-handle_06`, and use `raw-window-handle` version 0.6 types;
  *  `Window::from_raw_window` and `Window::from_window_raw_handle` are the two methods exposed by `raw-window-handle_05`, and use `raw-window-handle` version 0.5 types;
  * None of these methods are available if neither of the new Cargo features are enabled (which is the default).
* Made the `PluginGuiImpl` trait also take a lifetime parameter to account for that change.
* Added four new, unsafe `from_*` methods to allow creating the `Window` type from raw handles, either from the three standard GUI API types, or from a generic one.