### PR TITLE
New PluginDescriptor API, and Plugin initialization customization improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,22 @@ impl Plugin for MyGainPlugin {
 
     type Shared<'a> = ();
     type MainThread<'a> = ();
+}
 
+impl SimplePlugin for MyGainPlugin {
     fn get_descriptor() -> PluginDescriptor {
-      PluginDescriptor::new("org.rust-audio.clack.gain", "Clack Gain Example")
+        PluginDescriptor::new("org.rust-audio.clack.gain", "Clack Gain Example")
+    }
+
+    fn new_shared(_host: HostHandle) -> Result<Self::Shared<'_>, PluginError> {
+        Ok(())
+    }
+
+    fn new_main_thread<'a>(
+        _host: HostMainThreadHandle<'a>,
+        _shared: &'a Self::Shared<'a>,
+    ) -> Result<Self::MainThread<'a>, PluginError> {
+        Ok(())
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ impl Plugin for MyGainPlugin {
     type MainThread<'a> = ();
 }
 
-impl SimplePlugin for MyGainPlugin {
+impl DefaultPluginFactory for MyGainPlugin {
     fn get_descriptor() -> PluginDescriptor {
         PluginDescriptor::new("org.rust-audio.clack.gain", "Clack Gain Example")
     }

--- a/README.md
+++ b/README.md
@@ -79,12 +79,8 @@ impl Plugin for MyGainPlugin {
     type Shared<'a> = ();
     type MainThread<'a> = ();
 
-    fn get_descriptor() -> Box<dyn PluginDescriptor> {
-        Box::new(StaticPluginDescriptor {
-            id: CStr::from_bytes_with_nul(b"org.rust-audio.clack.gain\0").unwrap(),
-            name: CStr::from_bytes_with_nul(b"Clack Gain Example\0").unwrap(),
-            ..Default::default()
-        })
+    fn get_descriptor() -> PluginDescriptor {
+      PluginDescriptor::new("org.rust-audio.clack.gain", "Clack Gain Example")
     }
 }
 

--- a/extensions/src/__doc_utils.rs
+++ b/extensions/src/__doc_utils.rs
@@ -25,14 +25,7 @@ mod diva_stub {
 
     pub struct DivaPluginStubMainThread {}
 
-    impl<'a> PluginMainThread<'a, DivaPluginStubShared<'a>> for DivaPluginStubMainThread {
-        fn new(
-            _host: HostMainThreadHandle<'a>,
-            _shared: &'a DivaPluginStubShared,
-        ) -> Result<Self, PluginError> {
-            Ok(Self {})
-        }
-    }
+    impl<'a> PluginMainThread<'a, DivaPluginStubShared<'a>> for DivaPluginStubMainThread {}
 
     impl PluginStateImpl for DivaPluginStubMainThread {
         fn save(&mut self, output: &mut OutputStream) -> Result<(), PluginError> {
@@ -48,25 +41,34 @@ mod diva_stub {
         }
     }
 
-    impl<'a> PluginShared<'a> for DivaPluginStubShared<'a> {
-        fn new(host: HostHandle<'a>) -> Result<Self, PluginError> {
-            Ok(Self { host })
-        }
-    }
+    impl<'a> PluginShared<'a> for DivaPluginStubShared<'a> {}
 
     impl Plugin for DivaPluginStub {
         type AudioProcessor<'a> = DivaPluginStubAudioProcessor<'a>;
         type Shared<'a> = DivaPluginStubShared<'a>;
         type MainThread<'a> = DivaPluginStubMainThread;
 
+        fn declare_extensions(builder: &mut PluginExtensions<Self>, _shared: &Self::Shared<'_>) {
+            builder.register::<PluginState>();
+        }
+    }
+
+    impl SimplePlugin for DivaPluginStub {
         fn get_descriptor() -> PluginDescriptor {
             use clack_plugin::plugin::features::*;
 
             PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
         }
 
-        fn declare_extensions(builder: &mut PluginExtensions<Self>, _shared: &Self::Shared<'_>) {
-            builder.register::<PluginState>();
+        fn new_shared(host: HostHandle) -> Result<Self::Shared<'_>, PluginError> {
+            Ok(DivaPluginStubShared { host })
+        }
+
+        fn new_main_thread<'a>(
+            _host: HostMainThreadHandle<'a>,
+            _shared: &'a Self::Shared<'a>,
+        ) -> Result<Self::MainThread<'a>, PluginError> {
+            Ok(DivaPluginStubMainThread {})
         }
     }
 

--- a/extensions/src/__doc_utils.rs
+++ b/extensions/src/__doc_utils.rs
@@ -53,7 +53,7 @@ mod diva_stub {
         }
     }
 
-    impl SimplePlugin for DivaPluginStub {
+    impl DefaultPluginFactory for DivaPluginStub {
         fn get_descriptor() -> PluginDescriptor {
             use clack_plugin::plugin::features::*;
 

--- a/extensions/src/__doc_utils.rs
+++ b/extensions/src/__doc_utils.rs
@@ -12,7 +12,6 @@ mod diva_stub {
     use clack_common::stream::{InputStream, OutputStream};
     use clack_plugin::clack_entry;
     use clack_plugin::prelude::*;
-    use std::ffi::CStr;
     use std::io::{Read, Write};
 
     pub struct DivaPluginStub;
@@ -60,15 +59,10 @@ mod diva_stub {
         type Shared<'a> = DivaPluginStubShared<'a>;
         type MainThread<'a> = DivaPluginStubMainThread;
 
-        fn get_descriptor() -> Box<dyn PluginDescriptor> {
-            use clack_plugin::plugin::descriptor::features::*;
+        fn get_descriptor() -> PluginDescriptor {
+            use clack_plugin::plugin::features::*;
 
-            Box::new(StaticPluginDescriptor {
-                id: CStr::from_bytes_with_nul(b"com.u-he.diva\0").unwrap(),
-                name: CStr::from_bytes_with_nul(b"Diva\0").unwrap(),
-                features: Some(&[SYNTHESIZER, STEREO]),
-                ..Default::default()
-            })
+            PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
         }
 
         fn declare_extensions(builder: &mut PluginExtensions<Self>, _shared: &Self::Shared<'_>) {

--- a/host/src/bundle/diva_stub.rs
+++ b/host/src/bundle/diva_stub.rs
@@ -10,21 +10,30 @@ pub struct DivaPluginStubShared<'a> {
     host: HostHandle<'a>,
 }
 
-impl<'a> PluginShared<'a> for DivaPluginStubShared<'a> {
-    fn new(host: HostHandle<'a>) -> Result<Self, PluginError> {
-        Ok(Self { host })
-    }
-}
+impl<'a> PluginShared<'a> for DivaPluginStubShared<'a> {}
 
 impl Plugin for DivaPluginStub {
     type AudioProcessor<'a> = DivaPluginStubAudioProcessor<'a>;
     type Shared<'a> = DivaPluginStubShared<'a>;
     type MainThread<'a> = ();
+}
 
+impl SimplePlugin for DivaPluginStub {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 
         PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
+    }
+
+    fn new_shared(host: HostHandle) -> Result<Self::Shared<'_>, PluginError> {
+        Ok(DivaPluginStubShared { host })
+    }
+
+    fn new_main_thread<'a>(
+        _host: HostMainThreadHandle<'a>,
+        _shared: &'a Self::Shared<'a>,
+    ) -> Result<Self::MainThread<'a>, PluginError> {
+        Ok(())
     }
 }
 

--- a/host/src/bundle/diva_stub.rs
+++ b/host/src/bundle/diva_stub.rs
@@ -1,6 +1,5 @@
 use clack_plugin::clack_entry;
 use clack_plugin::prelude::*;
-use std::ffi::CStr;
 
 pub struct DivaPluginStub;
 
@@ -22,15 +21,10 @@ impl Plugin for DivaPluginStub {
     type Shared<'a> = DivaPluginStubShared<'a>;
     type MainThread<'a> = ();
 
-    fn get_descriptor() -> Box<dyn PluginDescriptor> {
-        use clack_plugin::plugin::descriptor::features::*;
+    fn get_descriptor() -> PluginDescriptor {
+        use clack_plugin::plugin::features::*;
 
-        Box::new(StaticPluginDescriptor {
-            id: CStr::from_bytes_with_nul(b"com.u-he.diva\0").unwrap(),
-            name: CStr::from_bytes_with_nul(b"Diva\0").unwrap(),
-            features: Some(&[SYNTHESIZER, STEREO]),
-            ..Default::default()
-        })
+        PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
     }
 }
 

--- a/host/src/bundle/diva_stub.rs
+++ b/host/src/bundle/diva_stub.rs
@@ -18,7 +18,7 @@ impl Plugin for DivaPluginStub {
     type MainThread<'a> = ();
 }
 
-impl SimplePlugin for DivaPluginStub {
+impl DefaultPluginFactory for DivaPluginStub {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 

--- a/host/tests/drop.rs
+++ b/host/tests/drop.rs
@@ -22,7 +22,7 @@ impl Plugin for DivaPluginStub {
     type MainThread<'a> = DivaPluginStubMainThread;
 }
 
-impl SimplePlugin for DivaPluginStub {
+impl DefaultPluginFactory for DivaPluginStub {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 

--- a/host/tests/drop.rs
+++ b/host/tests/drop.rs
@@ -25,15 +25,10 @@ impl Plugin for DivaPluginStub {
     type Shared<'a> = ();
     type MainThread<'a> = DivaPluginStubMainThread;
 
-    fn get_descriptor() -> Box<dyn PluginDescriptor> {
-        use clack_plugin::plugin::descriptor::features::*;
+    fn get_descriptor() -> PluginDescriptor {
+        use clack_plugin::plugin::features::*;
 
-        Box::new(StaticPluginDescriptor {
-            id: CStr::from_bytes_with_nul(b"com.u-he.diva\0").unwrap(),
-            name: CStr::from_bytes_with_nul(b"Diva\0").unwrap(),
-            features: Some(&[SYNTHESIZER, STEREO]),
-            ..Default::default()
-        })
+        PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
     }
 }
 

--- a/host/tests/drop.rs
+++ b/host/tests/drop.rs
@@ -14,21 +14,30 @@ pub struct DivaPluginStubMainThread {
     active: bool,
 }
 
-impl<'a> PluginMainThread<'a, ()> for DivaPluginStubMainThread {
-    fn new(_host: HostMainThreadHandle<'a>, _shared: &'a ()) -> Result<Self, PluginError> {
-        Ok(Self { active: false })
-    }
-}
+impl<'a> PluginMainThread<'a, ()> for DivaPluginStubMainThread {}
 
 impl Plugin for DivaPluginStub {
     type AudioProcessor<'a> = DivaPluginStubAudioProcessor;
     type Shared<'a> = ();
     type MainThread<'a> = DivaPluginStubMainThread;
+}
 
+impl SimplePlugin for DivaPluginStub {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 
         PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
+    }
+
+    fn new_shared(_host: HostHandle) -> Result<Self::Shared<'_>, PluginError> {
+        Ok(())
+    }
+
+    fn new_main_thread<'a>(
+        _host: HostMainThreadHandle<'a>,
+        _shared: &'a Self::Shared<'a>,
+    ) -> Result<Self::MainThread<'a>, PluginError> {
+        Ok(DivaPluginStubMainThread { active: false })
     }
 }
 

--- a/host/tests/instance.rs
+++ b/host/tests/instance.rs
@@ -20,15 +20,10 @@ impl Plugin for DivaPluginStub {
     type Shared<'a> = ();
     type MainThread<'a> = DivaPluginStubMainThread;
 
-    fn get_descriptor() -> Box<dyn PluginDescriptor> {
-        use clack_plugin::plugin::descriptor::features::*;
+    fn get_descriptor() -> PluginDescriptor {
+        use clack_plugin::plugin::features::*;
 
-        Box::new(StaticPluginDescriptor {
-            id: CStr::from_bytes_with_nul(b"com.u-he.diva\0").unwrap(),
-            name: CStr::from_bytes_with_nul(b"Diva\0").unwrap(),
-            features: Some(&[SYNTHESIZER, STEREO]),
-            ..Default::default()
-        })
+        PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
     }
 }
 

--- a/host/tests/instance.rs
+++ b/host/tests/instance.rs
@@ -9,21 +9,30 @@ pub struct DivaPluginStubAudioProcessor;
 pub struct DivaPluginStub;
 pub struct DivaPluginStubMainThread;
 
-impl<'a> PluginMainThread<'a, ()> for DivaPluginStubMainThread {
-    fn new(_host: HostMainThreadHandle<'a>, _shared: &'a ()) -> Result<Self, PluginError> {
-        Err(PluginError::AlreadyActivated)
-    }
-}
+impl<'a> PluginMainThread<'a, ()> for DivaPluginStubMainThread {}
 
 impl Plugin for DivaPluginStub {
     type AudioProcessor<'a> = DivaPluginStubAudioProcessor;
     type Shared<'a> = ();
     type MainThread<'a> = DivaPluginStubMainThread;
+}
 
+impl SimplePlugin for DivaPluginStub {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 
         PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
+    }
+
+    fn new_shared(_host: HostHandle) -> Result<Self::Shared<'_>, PluginError> {
+        Ok(())
+    }
+
+    fn new_main_thread<'a>(
+        _host: HostMainThreadHandle<'a>,
+        _shared: &'a Self::Shared<'a>,
+    ) -> Result<Self::MainThread<'a>, PluginError> {
+        Err(PluginError::AlreadyActivated)
     }
 }
 

--- a/host/tests/instance.rs
+++ b/host/tests/instance.rs
@@ -17,7 +17,7 @@ impl Plugin for DivaPluginStub {
     type MainThread<'a> = DivaPluginStubMainThread;
 }
 
-impl SimplePlugin for DivaPluginStub {
+impl DefaultPluginFactory for DivaPluginStub {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 

--- a/host/tests/shared-state.rs
+++ b/host/tests/shared-state.rs
@@ -19,15 +19,10 @@ impl Plugin for DivaPluginStub {
     type Shared<'a> = ();
     type MainThread<'a> = DivaPluginStubMainThread;
 
-    fn get_descriptor() -> Box<dyn PluginDescriptor> {
-        use clack_plugin::plugin::descriptor::features::*;
+    fn get_descriptor() -> PluginDescriptor {
+        use clack_plugin::plugin::features::*;
 
-        Box::new(StaticPluginDescriptor {
-            id: CStr::from_bytes_with_nul(b"com.u-he.diva\0").unwrap(),
-            name: CStr::from_bytes_with_nul(b"Diva\0").unwrap(),
-            features: Some(&[SYNTHESIZER, STEREO]),
-            ..Default::default()
-        })
+        PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
     }
 }
 

--- a/host/tests/shared-state.rs
+++ b/host/tests/shared-state.rs
@@ -8,21 +8,30 @@ pub struct DivaPluginStubAudioProcessor;
 pub struct DivaPluginStub;
 pub struct DivaPluginStubMainThread;
 
-impl<'a> PluginMainThread<'a, ()> for DivaPluginStubMainThread {
-    fn new(_host: HostMainThreadHandle<'a>, _shared: &'a ()) -> Result<Self, PluginError> {
-        Ok(Self)
-    }
-}
+impl<'a> PluginMainThread<'a, ()> for DivaPluginStubMainThread {}
 
 impl Plugin for DivaPluginStub {
     type AudioProcessor<'a> = DivaPluginStubAudioProcessor;
     type Shared<'a> = ();
     type MainThread<'a> = DivaPluginStubMainThread;
+}
 
+impl SimplePlugin for DivaPluginStub {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 
         PluginDescriptor::new("com.u-he.diva", "Diva").with_features([SYNTHESIZER, STEREO])
+    }
+
+    fn new_shared(_host: HostHandle) -> Result<Self::Shared<'_>, PluginError> {
+        Ok(())
+    }
+
+    fn new_main_thread<'a>(
+        _host: HostMainThreadHandle<'a>,
+        _shared: &'a Self::Shared<'a>,
+    ) -> Result<Self::MainThread<'a>, PluginError> {
+        Ok(DivaPluginStubMainThread {})
     }
 }
 

--- a/host/tests/shared-state.rs
+++ b/host/tests/shared-state.rs
@@ -16,7 +16,7 @@ impl Plugin for DivaPluginStub {
     type MainThread<'a> = DivaPluginStubMainThread;
 }
 
-impl SimplePlugin for DivaPluginStub {
+impl DefaultPluginFactory for DivaPluginStub {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 

--- a/plugin/examples/gain/src/lib.rs
+++ b/plugin/examples/gain/src/lib.rs
@@ -10,7 +10,6 @@ use clack_extensions::audio_ports::{
     AudioPortFlags, AudioPortInfoData, AudioPortInfoWriter, AudioPortType, PluginAudioPorts,
     PluginAudioPortsImpl,
 };
-use clack_plugin::process::audio::ChannelPair;
 use clack_plugin::utils::Cookie;
 
 pub struct GainPlugin;

--- a/plugin/examples/gain/src/lib.rs
+++ b/plugin/examples/gain/src/lib.rs
@@ -3,7 +3,6 @@
 
 use clack_extensions::params::info::ParamInfoFlags;
 use clack_extensions::params::{implementation::*, info::ParamInfoData, PluginParams};
-use std::ffi::CStr;
 
 use clack_plugin::prelude::*;
 
@@ -11,6 +10,7 @@ use clack_extensions::audio_ports::{
     AudioPortFlags, AudioPortInfoData, AudioPortInfoWriter, AudioPortType, PluginAudioPorts,
     PluginAudioPortsImpl,
 };
+use clack_plugin::process::audio::ChannelPair;
 use clack_plugin::utils::Cookie;
 
 pub struct GainPlugin;
@@ -20,15 +20,11 @@ impl Plugin for GainPlugin {
     type Shared<'a> = GainPluginShared<'a>;
     type MainThread<'a> = GainPluginMainThread<'a>;
 
-    fn get_descriptor() -> Box<dyn PluginDescriptor> {
-        use clack_plugin::plugin::descriptor::features::*;
+    fn get_descriptor() -> PluginDescriptor {
+        use clack_plugin::plugin::features::*;
 
-        Box::new(StaticPluginDescriptor {
-            id: CStr::from_bytes_with_nul(b"org.rust-audio.clack.gain\0").unwrap(),
-            name: CStr::from_bytes_with_nul(b"Clack Gain Example\0").unwrap(),
-            features: Some(&[SYNTHESIZER, STEREO]),
-            ..Default::default()
-        })
+        PluginDescriptor::new("org.rust-audio.clack.gain", "Clack Gain Example")
+            .with_features([SYNTHESIZER, STEREO])
     }
 
     fn declare_extensions(builder: &mut PluginExtensions<Self>, _shared: &GainPluginShared) {

--- a/plugin/examples/gain/src/lib.rs
+++ b/plugin/examples/gain/src/lib.rs
@@ -26,7 +26,7 @@ impl Plugin for GainPlugin {
     }
 }
 
-impl SimplePlugin for GainPlugin {
+impl DefaultPluginFactory for GainPlugin {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 

--- a/plugin/examples/gain/src/lib.rs
+++ b/plugin/examples/gain/src/lib.rs
@@ -19,17 +19,34 @@ impl Plugin for GainPlugin {
     type Shared<'a> = GainPluginShared<'a>;
     type MainThread<'a> = GainPluginMainThread<'a>;
 
-    fn get_descriptor() -> PluginDescriptor {
-        use clack_plugin::plugin::features::*;
-
-        PluginDescriptor::new("org.rust-audio.clack.gain", "Clack Gain Example")
-            .with_features([SYNTHESIZER, STEREO])
-    }
-
     fn declare_extensions(builder: &mut PluginExtensions<Self>, _shared: &GainPluginShared) {
         builder
             .register::<PluginParams>()
             .register::<PluginAudioPorts>();
+    }
+}
+
+impl SimplePlugin for GainPlugin {
+    fn get_descriptor() -> PluginDescriptor {
+        use clack_plugin::plugin::features::*;
+
+        PluginDescriptor::new("org.rust-audio.clack.gain", "Clack Gain Example")
+            .with_features([STEREO])
+    }
+
+    fn new_shared(host: HostHandle) -> Result<Self::Shared<'_>, PluginError> {
+        Ok(GainPluginShared { _host: host })
+    }
+
+    fn new_main_thread<'a>(
+        host: HostMainThreadHandle<'a>,
+        shared: &'a Self::Shared<'a>,
+    ) -> Result<Self::MainThread<'a>, PluginError> {
+        Ok(Self::MainThread {
+            rusting: 0,
+            shared,
+            _host: host,
+        })
     }
 }
 
@@ -116,11 +133,7 @@ pub struct GainPluginShared<'a> {
     _host: HostHandle<'a>,
 }
 
-impl<'a> PluginShared<'a> for GainPluginShared<'a> {
-    fn new(host: HostHandle<'a>) -> Result<Self, PluginError> {
-        Ok(Self { _host: host })
-    }
-}
+impl<'a> PluginShared<'a> for GainPluginShared<'a> {}
 
 pub struct GainPluginMainThread<'a> {
     rusting: u32,
@@ -130,18 +143,7 @@ pub struct GainPluginMainThread<'a> {
     _host: HostMainThreadHandle<'a>,
 }
 
-impl<'a> PluginMainThread<'a, GainPluginShared<'a>> for GainPluginMainThread<'a> {
-    fn new(
-        host: HostMainThreadHandle<'a>,
-        shared: &'a GainPluginShared,
-    ) -> Result<Self, PluginError> {
-        Ok(Self {
-            rusting: 0,
-            shared,
-            _host: host,
-        })
-    }
-}
+impl<'a> PluginMainThread<'a, GainPluginShared<'a>> for GainPluginMainThread<'a> {}
 
 impl<'a> PluginMainThreadParams for GainPluginMainThread<'a> {
     fn count(&mut self) -> u32 {

--- a/plugin/examples/gain/tests/test_gain.rs
+++ b/plugin/examples/gain/tests/test_gain.rs
@@ -43,7 +43,7 @@ pub fn it_works() {
             .features()
             .map(|s| s.to_bytes())
             .collect::<Vec<_>>(),
-        &[&b"synthesizer"[..], &b"stereo"[..]]
+        &[&b"stereo"[..]]
     );
 
     let plugin = host.plugin_mut();

--- a/plugin/examples/polysynth/src/lib.rs
+++ b/plugin/examples/polysynth/src/lib.rs
@@ -22,16 +22,11 @@ impl Plugin for PolySynthPlugin {
     type Shared<'a> = PolySynthPluginShared;
     type MainThread<'a> = PolySynthPluginMainThread<'a>;
 
-    fn get_descriptor() -> Box<dyn PluginDescriptor> {
-        use clack_plugin::plugin::descriptor::features::*;
-        use std::ffi::CStr;
+    fn get_descriptor() -> PluginDescriptor {
+        use clack_plugin::plugin::features::*;
 
-        Box::new(StaticPluginDescriptor {
-            id: CStr::from_bytes_with_nul(b"org.rust-audio.clack.polysynth\0").unwrap(),
-            name: CStr::from_bytes_with_nul(b"Clack PolySynth Example\0").unwrap(),
-            features: Some(&[SYNTHESIZER, MONO, INSTRUMENT]),
-            ..Default::default()
-        })
+        PluginDescriptor::new("org.rust-audio.clack.polysynth", "Clack PolySynth Example")
+            .with_features([SYNTHESIZER, MONO, INSTRUMENT])
     }
 
     fn declare_extensions(builder: &mut PluginExtensions<Self>, _shared: &PolySynthPluginShared) {

--- a/plugin/examples/polysynth/src/lib.rs
+++ b/plugin/examples/polysynth/src/lib.rs
@@ -31,7 +31,7 @@ impl Plugin for PolySynthPlugin {
     }
 }
 
-impl SimplePlugin for PolySynthPlugin {
+impl DefaultPluginFactory for PolySynthPlugin {
     fn get_descriptor() -> PluginDescriptor {
         use clack_plugin::plugin::features::*;
 

--- a/plugin/src/entry.rs
+++ b/plugin/src/entry.rs
@@ -44,7 +44,7 @@ pub mod prelude {
             Factory,
         },
         host::HostInfo,
-        plugin::{descriptor::PluginDescriptorWrapper, PluginInstance},
+        plugin::{PluginDescriptor, PluginInstance},
     };
 }
 
@@ -75,7 +75,7 @@ pub mod prelude {
 /// impl Plugin for MyFirstPlugin {
 ///     /* ... */
 /// #   type AudioProcessor<'a> = (); type Shared<'a> = (); type MainThread<'a> = ();
-/// #   fn get_descriptor() -> Box<dyn PluginDescriptor> {
+/// #   fn get_descriptor() -> PluginDescriptor {
 /// #       unreachable!()
 /// #   }
 /// }
@@ -83,7 +83,7 @@ pub mod prelude {
 /// impl Plugin for MySecondPlugin {
 ///     /* ... */
 /// #   type AudioProcessor<'a> = (); type Shared<'a> = (); type MainThread<'a> = ();
-/// #   fn get_descriptor() -> Box<dyn PluginDescriptor> {
+/// #   fn get_descriptor() -> PluginDescriptor {
 /// #       unreachable!()
 /// #   }
 /// }
@@ -106,15 +106,15 @@ pub mod prelude {
 ///
 /// // Our factory holds the descriptors for both of our plugins
 /// pub struct MyPluginFactory {
-///     first_plugin: PluginDescriptorWrapper,
-///     second_plugin: PluginDescriptorWrapper,
+///     first_plugin: PluginDescriptor,
+///     second_plugin: PluginDescriptor,
 /// }
 ///
 /// impl MyPluginFactory {
 ///     pub fn new() -> Self {
 ///         Self {
-///             first_plugin: PluginDescriptorWrapper::new(MyFirstPlugin::get_descriptor()),
-///             second_plugin: PluginDescriptorWrapper::new(MySecondPlugin::get_descriptor()),
+///             first_plugin: MyFirstPlugin::get_descriptor(),
+///             second_plugin: MySecondPlugin::get_descriptor(),
 ///         }
 ///     }
 /// }
@@ -126,8 +126,8 @@ pub mod prelude {
 ///
 ///     // Gets the plugin descriptor matching the given index.
 ///     // It doesn't matter much which plugin has which index,
-///     // but each of our plugins must have an unique one.
-///     fn plugin_descriptor(&self, index: u32) -> Option<&PluginDescriptorWrapper> {
+///     // but each of our plugins must have a unique one.
+///     fn plugin_descriptor(&self, index: u32) -> Option<&PluginDescriptor> {
 ///         match index {
 ///             0 => Some(&self.first_plugin),
 ///             1 => Some(&self.second_plugin),
@@ -142,11 +142,11 @@ pub mod prelude {
 ///         host_info: HostInfo<'a>,
 ///         plugin_id: &CStr,
 ///     ) -> Option<PluginInstance<'a>> {
-///         if plugin_id == self.first_plugin.descriptor().id() {
+///         if plugin_id == self.first_plugin.id() {
 ///             // We can use the PluginInstance type to easily make a new instance of a given
 ///             // plugin type.
 ///             Some(PluginInstance::new::<MyFirstPlugin>(host_info, &self.first_plugin))
-///         } else if plugin_id == self.second_plugin.descriptor().id() {
+///         } else if plugin_id == self.second_plugin.id() {
 ///             Some(PluginInstance::new::<MySecondPlugin>(host_info, &self.second_plugin))
 ///         } else {
 ///             None

--- a/plugin/src/entry.rs
+++ b/plugin/src/entry.rs
@@ -367,13 +367,9 @@ enum EntryHolderInner<E> {
 }
 
 #[doc(hidden)]
-pub struct EntryHolder<E> {
+pub struct EntryHolder<E: Entry> {
     inner: Mutex<EntryHolderInner<E>>,
 }
-
-// SAFETY: TODO
-unsafe impl<E> Send for EntryHolder<E> {}
-unsafe impl<E> Sync for EntryHolder<E> {}
 
 use crate::entry::EntryHolderInner::*;
 

--- a/plugin/src/entry.rs
+++ b/plugin/src/entry.rs
@@ -33,7 +33,7 @@ pub use clack_common::entry::*;
 
 mod single;
 
-pub use single::SinglePluginEntry;
+pub use single::{SimplePlugin, SinglePluginEntry};
 
 /// A prelude that's helpful for implementing custom [`Entry`] and [`PluginFactory`](crate::factory::plugin::PluginFactory) types.
 pub mod prelude {
@@ -73,19 +73,15 @@ pub mod prelude {
 /// pub struct MySecondPlugin;
 ///
 /// impl Plugin for MyFirstPlugin {
-///     /* ... */
-/// #   type AudioProcessor<'a> = (); type Shared<'a> = (); type MainThread<'a> = ();
-/// #   fn get_descriptor() -> PluginDescriptor {
-/// #       unreachable!()
-/// #   }
+///     type AudioProcessor<'a> = ();
+///     type Shared<'a> = ();
+///     type MainThread<'a> = ();
 /// }
 ///
 /// impl Plugin for MySecondPlugin {
-///     /* ... */
-/// #   type AudioProcessor<'a> = (); type Shared<'a> = (); type MainThread<'a> = ();
-/// #   fn get_descriptor() -> PluginDescriptor {
-/// #       unreachable!()
-/// #   }
+///     type AudioProcessor<'a> = ();
+///     type Shared<'a> = ();
+///     type MainThread<'a> = ();
 /// }
 ///
 /// pub struct MyEntry {
@@ -113,8 +109,8 @@ pub mod prelude {
 /// impl MyPluginFactory {
 ///     pub fn new() -> Self {
 ///         Self {
-///             first_plugin: MyFirstPlugin::get_descriptor(),
-///             second_plugin: MySecondPlugin::get_descriptor(),
+///             first_plugin: PluginDescriptor::new("my.plugin.first", "My first plugin"),
+///             second_plugin: PluginDescriptor::new("my.plugin.second", "My second plugin"),
 ///         }
 ///     }
 /// }
@@ -145,9 +141,19 @@ pub mod prelude {
 ///         if plugin_id == self.first_plugin.id() {
 ///             // We can use the PluginInstance type to easily make a new instance of a given
 ///             // plugin type.
-///             Some(PluginInstance::new::<MyFirstPlugin>(host_info, &self.first_plugin))
+///             Some(PluginInstance::new::<MyFirstPlugin>(
+///                 host_info,
+///                 &self.first_plugin,
+///                 |_host| Ok(()) /* Create the shared struct */,
+///                 |_host, _shared| Ok(()) /* Create the main thread struct */,
+///             ))
 ///         } else if plugin_id == self.second_plugin.id() {
-///             Some(PluginInstance::new::<MySecondPlugin>(host_info, &self.second_plugin))
+///             Some(PluginInstance::new::<MySecondPlugin>(
+///                 host_info,
+///                 &self.second_plugin,
+///                 |_host| Ok(()) /* Create the shared struct */,
+///                 |_host, _shared| Ok(()) /* Create the main thread struct */,
+///             ))
 ///         } else {
 ///             None
 ///         }

--- a/plugin/src/entry.rs
+++ b/plugin/src/entry.rs
@@ -33,7 +33,7 @@ pub use clack_common::entry::*;
 
 mod single;
 
-pub use single::{SimplePlugin, SinglePluginEntry};
+pub use single::{DefaultPluginFactory, SinglePluginEntry};
 
 /// A prelude that's helpful for implementing custom [`Entry`] and [`PluginFactory`](crate::factory::plugin::PluginFactory) types.
 pub mod prelude {
@@ -133,7 +133,7 @@ pub mod prelude {
 ///
 ///     // Called when the host desires to create a new instance of one of our plugins.
 ///     // Which plugin it is, is determined by the given plugin_id.
-///     fn instantiate_plugin<'a>(
+///     fn create_plugin<'a>(
 ///         &'a self,
 ///         host_info: HostInfo<'a>,
 ///         plugin_id: &CStr,

--- a/plugin/src/extensions/wrapper.rs
+++ b/plugin/src/extensions/wrapper.rs
@@ -206,7 +206,7 @@ impl<'a, P: Plugin> PluginWrapper<'a, P> {
     ///
     /// # Example
     ///
-    /// This is the implementation of the [`on_main_thread`](PluginMainThread::on_main_thread)
+    /// This is the implementation of the [`on_main_thread`](crate::plugin::PluginMainThread::on_main_thread)
     /// callback's C wrapper.
     ///
     /// This method is guaranteed by the CLAP specification to be only called on the main thread.

--- a/plugin/src/factory/plugin.rs
+++ b/plugin/src/factory/plugin.rs
@@ -10,8 +10,7 @@
 
 use crate::factory::Factory;
 use crate::host::HostInfo;
-use crate::plugin::descriptor::PluginDescriptorWrapper;
-use crate::plugin::PluginInstance;
+use crate::plugin::{PluginDescriptor, PluginInstance};
 use clap_sys::factory::plugin_factory::{clap_plugin_factory, CLAP_PLUGIN_FACTORY_ID};
 use clap_sys::host::clap_host;
 use clap_sys::plugin::{clap_plugin, clap_plugin_descriptor};
@@ -112,13 +111,13 @@ unsafe impl<F> Factory for PluginFactoryWrapper<F> {
 /// impl Plugin for MyPlugin {
 ///     /* ... */
 /// #   type AudioProcessor<'a> = (); type Shared<'a> = (); type MainThread<'a> = ();
-/// #   fn get_descriptor() -> Box<dyn PluginDescriptor> {
+/// #   fn get_descriptor() -> PluginDescriptor {
 /// #       unreachable!()
 /// #   }
 /// }
 ///
 /// pub struct MyPluginFactory {
-///     plugin_descriptor: PluginDescriptorWrapper
+///     plugin_descriptor: PluginDescriptor
 /// }
 ///
 /// impl PluginFactory for MyPluginFactory {
@@ -126,7 +125,7 @@ unsafe impl<F> Factory for PluginFactoryWrapper<F> {
 ///         1 // We only have a single plugin
 ///     }
 ///
-///     fn plugin_descriptor(&self, index: u32) -> Option<&PluginDescriptorWrapper> {
+///     fn plugin_descriptor(&self, index: u32) -> Option<&PluginDescriptor> {
 ///         match index {
 ///             0 => Some(&self.plugin_descriptor),
 ///             _ => None
@@ -145,8 +144,8 @@ unsafe impl<F> Factory for PluginFactoryWrapper<F> {
 pub trait PluginFactory: Send + Sync {
     /// Returns the number of plugins exposed by this factory.
     fn plugin_count(&self) -> u32;
-    /// Returns the [`PluginDescriptorWrapper`] wrapping the descriptor of a plugin that is assigned
-    /// to the given index.
+
+    /// Returns the [`PluginDescriptor`] of the plugin that is assigned the given index.
     ///
     /// Hosts will usually call this method repeatedly with every index from 0 to the total returned
     /// by [`plugin_count`](PluginFactory::plugin_count), in order to discover all the plugins
@@ -154,7 +153,7 @@ pub trait PluginFactory: Send + Sync {
     ///
     /// If the given index is out of bounds, or in general does not match any given plugin, this
     /// returns [`None`].
-    fn plugin_descriptor(&self, index: u32) -> Option<&PluginDescriptorWrapper>;
+    fn plugin_descriptor(&self, index: u32) -> Option<&PluginDescriptor>;
 
     /// Creates a new plugin instance for the plugin type matching the given `plugin_id`.
     ///

--- a/plugin/src/factory/plugin.rs
+++ b/plugin/src/factory/plugin.rs
@@ -82,7 +82,7 @@ impl<F: PluginFactory> PluginFactoryWrapper<F> {
         let host_info = HostInfo::from_raw(clap_host);
         let this = &*(factory as *const Self);
 
-        match this.factory.instantiate_plugin(host_info, plugin_id) {
+        match this.factory.create_plugin(host_info, plugin_id) {
             None => core::ptr::null(),
             Some(instance) => instance.into_owned_ptr(),
         }
@@ -130,7 +130,7 @@ unsafe impl<F> Factory for PluginFactoryWrapper<F> {
 ///         }
 ///     }
 ///
-///     fn instantiate_plugin<'a>(&'a self, host_info: HostInfo<'a>, plugin_id: &CStr) -> Option<PluginInstance<'a>> {
+///     fn create_plugin<'a>(&'a self, host_info: HostInfo<'a>, plugin_id: &CStr) -> Option<PluginInstance<'a>> {
 ///         if plugin_id == self.plugin_descriptor.id() {
 ///             Some(PluginInstance::new::<MyPlugin>(
 ///                 host_info,
@@ -166,7 +166,7 @@ pub trait PluginFactory: Send + Sync {
     ///
     /// If the given `plugin_id` does not match any known plugins to this factory, this method
     /// returns [`None`].
-    fn instantiate_plugin<'a>(
+    fn create_plugin<'a>(
         &'a self,
         host_info: HostInfo<'a>,
         plugin_id: &CStr,

--- a/plugin/src/factory/plugin.rs
+++ b/plugin/src/factory/plugin.rs
@@ -109,11 +109,9 @@ unsafe impl<F> Factory for PluginFactoryWrapper<F> {
 /// pub struct MyPlugin;
 ///
 /// impl Plugin for MyPlugin {
-///     /* ... */
-/// #   type AudioProcessor<'a> = (); type Shared<'a> = (); type MainThread<'a> = ();
-/// #   fn get_descriptor() -> PluginDescriptor {
-/// #       unreachable!()
-/// #   }
+///     type AudioProcessor<'a> = ();
+///     type Shared<'a> = ();
+///     type MainThread<'a> = ();
 /// }
 ///
 /// pub struct MyPluginFactory {
@@ -134,7 +132,12 @@ unsafe impl<F> Factory for PluginFactoryWrapper<F> {
 ///
 ///     fn instantiate_plugin<'a>(&'a self, host_info: HostInfo<'a>, plugin_id: &CStr) -> Option<PluginInstance<'a>> {
 ///         if plugin_id == self.plugin_descriptor.id() {
-///             Some(PluginInstance::new::<MyPlugin>(host_info, &self.plugin_descriptor))
+///             Some(PluginInstance::new::<MyPlugin>(
+///                 host_info,
+///                 &self.plugin_descriptor,
+///                 |_host| Ok(()) /* Create the shared struct */,
+///                 |_host, _shared| Ok(()) /* Create the main thread struct */,
+///             ))
 ///         } else {
 ///             None
 ///         }

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -28,9 +28,8 @@ pub mod prelude {
     pub use crate::extensions::PluginExtensions;
     pub use crate::host::{HostAudioThreadHandle, HostHandle, HostMainThreadHandle};
     pub use crate::plugin::{
-        descriptor::{PluginDescriptor, StaticPluginDescriptor},
-        AudioConfiguration, Plugin, PluginAudioProcessor, PluginError, PluginMainThread,
-        PluginShared,
+        AudioConfiguration, Plugin, PluginAudioProcessor, PluginDescriptor, PluginError,
+        PluginMainThread, PluginShared,
     };
     pub use crate::process::{
         audio::{ChannelPair, SampleType},

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -20,7 +20,7 @@ pub use clack_common::utils;
 /// A helpful prelude re-exporting all the types related to plugin implementation.
 pub mod prelude {
     pub use crate::clack_export_entry;
-    pub use crate::entry::{Entry, EntryDescriptor, SimplePlugin, SinglePluginEntry};
+    pub use crate::entry::{DefaultPluginFactory, Entry, EntryDescriptor, SinglePluginEntry};
     pub use crate::events::{
         io::{InputEvents, OutputEvents},
         UnknownEvent,

--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -20,7 +20,7 @@ pub use clack_common::utils;
 /// A helpful prelude re-exporting all the types related to plugin implementation.
 pub mod prelude {
     pub use crate::clack_export_entry;
-    pub use crate::entry::{Entry, EntryDescriptor, SinglePluginEntry};
+    pub use crate::entry::{Entry, EntryDescriptor, SimplePlugin, SinglePluginEntry};
     pub use crate::events::{
         io::{InputEvents, OutputEvents},
         UnknownEvent,

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -40,14 +40,14 @@
 //!   shared between the main thread and the audio thread. If it isn't needed , `()` can be used
 //!   instead.
 //!
-//!   It can be used to hold read-only data (such as all of the detected host extensions), or to
+//!   It can be used to hold read-only data (such as all the detected host extensions), or to
 //!   hold any other kind of synchronized state.
 //!
 //!   However, it should be noted that this type *can* be used by the host simultaneously from
 //!   threads that are neither the main thread nor the audio thread.
 
 use crate::extensions::PluginExtensions;
-use crate::host::{HostAudioThreadHandle, HostHandle, HostMainThreadHandle};
+use crate::host::HostAudioThreadHandle;
 use crate::process::Audio;
 use crate::process::Events;
 use crate::process::Process;
@@ -71,23 +71,9 @@ pub use instance::*;
 /// threads, including (but not limited to) the main thread and the audio thread.
 ///
 /// See the [module documentation](crate::plugin) for more information on the thread model.
-pub trait PluginShared<'a>: Sized + Send + Sync + 'a {
-    /// Creates a new instance of this shared data.
-    ///
-    /// This struct receives a thread-safe host handle that can be stored for the lifetime of the plugin.
-    ///
-    /// # Errors
-    /// This operation may fail for any reason, in which case `Err` is returned and the plugin is
-    /// not instantiated.
-    fn new(host: HostHandle<'a>) -> Result<Self, PluginError>;
-}
+pub trait PluginShared<'a>: Sized + Send + Sync + 'a {}
 
-impl<'a> PluginShared<'a> for () {
-    #[inline]
-    fn new(_host: HostHandle<'a>) -> Result<Self, PluginError> {
-        Ok(())
-    }
-}
+impl<'a> PluginShared<'a> for () {}
 
 /// The part of the data and operation of a plugin that must be on the main thread.
 ///
@@ -99,15 +85,6 @@ impl<'a> PluginShared<'a> for () {
 ///
 /// See the [module documentation](crate::plugin) for more information on the thread model.
 pub trait PluginMainThread<'a, S: PluginShared<'a>>: Sized + 'a {
-    /// Creates a new instance of the plugin's main thread.
-    ///
-    /// This struct receives an exclusive host handle that can be stored for the lifetime of the plugin.
-    ///
-    /// # Errors
-    /// This operation may fail for any reason, in which case `Err` is returned and the plugin is
-    /// not instantiated.
-    fn new(host: HostMainThreadHandle<'a>, shared: &'a S) -> Result<Self, PluginError>;
-
     /// This is called by the host on the main thread, in response to a previous call to
     /// [`HostHandle::request_callback`](HostHandle::request_callback).
     ///
@@ -116,12 +93,7 @@ pub trait PluginMainThread<'a, S: PluginShared<'a>>: Sized + 'a {
     fn on_main_thread(&mut self) {}
 }
 
-impl<'a, S: PluginShared<'a>> PluginMainThread<'a, S> for () {
-    #[inline]
-    fn new(_host: HostMainThreadHandle<'a>, _shared: &'a S) -> Result<Self, PluginError> {
-        Ok(())
-    }
-}
+impl<'a, S: PluginShared<'a>> PluginMainThread<'a, S> for () {}
 
 /// The audio configuration passed to a plugin's audio processor upon activation.
 ///
@@ -157,12 +129,6 @@ pub trait Plugin: 'static {
     ///
     /// See the [module documentation](crate::plugin) for more information on the thread model.
     type MainThread<'a>: PluginMainThread<'a, Self::Shared<'a>>;
-
-    /// Returns a new Plugin Descriptor, which contains metadata about the plugin, such as its name,
-    /// stable identifier, and more.
-    ///
-    /// See the [`PluginDescriptor`] type's documentation for more information.
-    fn get_descriptor() -> PluginDescriptor;
 
     #[inline]
     #[allow(unused_variables)]

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -53,12 +53,12 @@ use crate::process::Events;
 use crate::process::Process;
 use clack_common::process::ProcessStatus;
 
-pub mod descriptor;
+mod descriptor;
 mod error;
 mod instance;
 pub(crate) mod logging;
 
-use crate::plugin::descriptor::PluginDescriptor;
+pub use descriptor::*;
 pub use error::PluginError;
 pub use instance::*;
 
@@ -158,12 +158,11 @@ pub trait Plugin: 'static {
     /// See the [module documentation](crate::plugin) for more information on the thread model.
     type MainThread<'a>: PluginMainThread<'a, Self::Shared<'a>>;
 
-    /// Creates a new Plugin Descriptor.
+    /// Returns a new Plugin Descriptor, which contains metadata about the plugin, such as its name,
+    /// stable identifier, and more.
     ///
-    /// This contains read-only data about the plugin, such as it's name, stable identifier, and more.
-    ///
-    /// See the [`PluginDescriptor`] trait's documentation for more information.
-    fn get_descriptor() -> Box<dyn PluginDescriptor>;
+    /// See the [`PluginDescriptor`] type's documentation for more information.
+    fn get_descriptor() -> PluginDescriptor;
 
     #[inline]
     #[allow(unused_variables)]

--- a/plugin/src/plugin.rs
+++ b/plugin/src/plugin.rs
@@ -86,7 +86,7 @@ impl<'a> PluginShared<'a> for () {}
 /// See the [module documentation](crate::plugin) for more information on the thread model.
 pub trait PluginMainThread<'a, S: PluginShared<'a>>: Sized + 'a {
     /// This is called by the host on the main thread, in response to a previous call to
-    /// [`HostHandle::request_callback`](HostHandle::request_callback).
+    /// [`HostHandle::request_callback`](crate::host::HostHandle::request_callback).
     ///
     /// The default implementation of this method does nothing.
     #[inline]

--- a/plugin/src/plugin/descriptor.rs
+++ b/plugin/src/plugin/descriptor.rs
@@ -1,23 +1,145 @@
+#![deny(missing_docs)]
+
 use clap_sys::plugin::clap_plugin_descriptor;
 use clap_sys::version::CLAP_VERSION;
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
 /// Represents a type that can provide metadata about a given Plugin, such as its ID, name, version,
 /// and more.
 ///
 /// Note only the [`id`](PluginDescriptor::id) and [`name`](PluginDescriptor::name) fields are
-/// mandatory, and should not be blank. All of the other fields are optional and can return [`None`].
+/// mandatory, and should not be blank. All the other fields are optional.
 ///
-/// See the documentation of each individual method to learn about the available metadata.
-pub trait PluginDescriptor: Send + Sync + 'static {
+/// See the documentation each accessor method to learn about the available metadata.
+///
+/// # Example
+///
+/// ```
+/// use clack_plugin::prelude::PluginDescriptor;
+///
+/// fn get_descriptor() -> PluginDescriptor {
+///   use clack_plugin::plugin::features::*;
+///
+///   PluginDescriptor::new("org.rust-audio.clack.gain", "Clack Gain Example")
+///     .with_description("A simple gain plugin example!")
+///     .with_version("0.1.0")
+///     .with_features([SYNTHESIZER, STEREO])
+/// }
+/// ```
+pub struct PluginDescriptor {
+    id: CString,
+    name: CString,
+
+    vendor: Option<CString>,
+    url: Option<CString>,
+    manual_url: Option<CString>,
+    support_url: Option<CString>,
+    version: Option<CString>,
+    description: Option<CString>,
+
+    features: Vec<CString>,
+    features_array: Vec<*const c_char>,
+
+    raw_descriptor: clap_plugin_descriptor,
+}
+
+// SAFETY: PluginDescriptor is fully self-contained, the pointers refer to data owned by it.
+unsafe impl Send for PluginDescriptor {}
+
+// SAFETY: PluginDescriptor does not have any interior mutability.
+unsafe impl Sync for PluginDescriptor {}
+
+// SAFETY: there is a null byte in this string.
+const EMPTY: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"\0") };
+const EMPTY_FEATURES: &[*const c_char] = &[core::ptr::null()];
+
+impl PluginDescriptor {
+    /// Creates a new plugin descriptor, initializing it with the given Plugin ID and name.
+    ///
+    /// See the documentation of the [`id`](PluginDescriptor::id) and
+    /// [`name`](PluginDescriptor::name) methods for more information about the `id` and `name`
+    /// parameters.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if either the given ID or name are empty strings.
+    ///
+    /// This function will also panic if either the given ID or name contain invalid NULL-byte
+    /// characters, which are invalid.
+    pub fn new(id: &str, name: &str) -> Self {
+        let id = CString::new(id).expect("Invalid Plugin ID");
+        let name = CString::new(name).expect("Invalid Plugin Name");
+
+        if id.is_empty() {
+            panic!("Plugin ID must not be blank!");
+        }
+
+        if name.is_empty() {
+            panic!("Plugin Name must not be blank!");
+        }
+
+        Self {
+            raw_descriptor: clap_plugin_descriptor {
+                clap_version: CLAP_VERSION,
+                id: id.as_ptr(),
+                name: name.as_ptr(),
+                vendor: EMPTY.as_ptr(),
+                url: EMPTY.as_ptr(),
+                manual_url: EMPTY.as_ptr(),
+                support_url: EMPTY.as_ptr(),
+                version: EMPTY.as_ptr(),
+                description: EMPTY.as_ptr(),
+                features: EMPTY_FEATURES.as_ptr(),
+            },
+
+            id,
+            name,
+
+            vendor: None,
+            url: None,
+            manual_url: None,
+            support_url: None,
+            version: None,
+            description: None,
+
+            features: vec![],
+            features_array: vec![],
+        }
+    }
+
     /// The unique identifier of a plugin. This field is **mandatory**, and should not be blank.
     ///
     /// This identifier should be as globally-unique as possible to any users that might load this
     /// plugin, as this is the key hosts will use to differentiate between different plugins.
     ///
     /// Example: `com.u-he.diva`.
-    fn id(&self) -> &CStr;
+    #[inline]
+    pub fn id(&self) -> &CStr {
+        &self.id
+    }
+
+    /// Sets the plugin's unique ID.
+    ///
+    /// See the [`id`](PluginDescriptor::id) method documentation for more information.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the given ID is an empty string.
+    ///
+    /// This function will also panic if the given ID contains NULL-byte characters, which are invalid.
+    pub fn with_id(mut self, id: &str) -> Self {
+        if id.is_empty() {
+            panic!("Plugin ID must not be blank!");
+        }
+
+        let id = CString::new(id).expect("Invalid Plugin ID");
+
+        self.raw_descriptor.id = id.as_ptr();
+        self.id = id;
+
+        self
+    }
 
     /// The user-facing display name of this plugin. This field is **mandatory**, and should not be blank.
     ///
@@ -25,57 +147,232 @@ pub trait PluginDescriptor: Send + Sync + 'static {
     /// will find and differentiate the plugin.
     ///
     /// Example: `Diva`.
-    fn name(&self) -> &CStr;
+    #[inline]
+    pub fn name(&self) -> &CStr {
+        &self.name
+    }
+
+    /// Sets the plugin's name.
+    ///
+    /// See the [`name`](PluginDescriptor::name) method documentation for more information.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the given name is an empty string.
+    ///
+    /// This function will also panic if the given name contains NULL-byte characters, which are invalid.
+    pub fn with_name(mut self, name: &str) -> Self {
+        if name.is_empty() {
+            panic!("Plugin name must not be blank!");
+        }
+
+        let name = CString::new(name).expect("Invalid Plugin name");
+
+        self.raw_descriptor.name = name.as_ptr();
+        self.name = name;
+
+        self
+    }
 
     /// The vendor of the plugin.
     ///
     /// Example: `u-he`.
     #[inline]
-    fn vendor(&self) -> Option<&CStr> {
-        None
+    pub fn vendor(&self) -> Option<&CStr> {
+        self.vendor.as_deref()
+    }
+
+    /// Sets the plugin's vendor name.
+    ///
+    /// See the [`vendor`](PluginDescriptor::vendor) method documentation for more information.
+    ///
+    /// Passing an empty string as the `vendor` parameter will mark it as unset, making
+    /// [`vendor`](PluginDescriptor::vendor) then return `None`.
+    ///
+    /// # Panics
+    ///
+    /// This function will also panic if the given vendor name contains NULL-byte characters,
+    /// which are invalid.
+    pub fn with_vendor(mut self, vendor: &str) -> Self {
+        if vendor.is_empty() {
+            self.raw_descriptor.vendor = EMPTY.as_ptr();
+            self.vendor = None;
+        } else {
+            let vendor = CString::new(vendor).expect("Invalid Plugin vendor");
+
+            self.raw_descriptor.vendor = vendor.as_ptr();
+            self.vendor = Some(vendor);
+        }
+
+        self
     }
 
     /// The URL of this plugin's homepage.
     ///
     /// Example: `https://u-he.com/products/diva/`.
     #[inline]
-    fn url(&self) -> Option<&CStr> {
-        None
+    pub fn url(&self) -> Option<&CStr> {
+        self.url.as_deref()
+    }
+
+    /// Sets the plugin's homepage's URL.
+    ///
+    /// See the [`url`](PluginDescriptor::url) method documentation for more information.
+    ///
+    /// Passing an empty string as the `url` parameter will mark it as unset, making
+    /// [`url`](PluginDescriptor::url) then return `None`.
+    ///
+    /// # Panics
+    ///
+    /// This function will also panic if the given URL contains NULL-byte characters,
+    /// which are invalid.
+    pub fn with_url(mut self, url: &str) -> Self {
+        if url.is_empty() {
+            self.raw_descriptor.url = EMPTY.as_ptr();
+            self.url = None;
+        } else {
+            let url = CString::new(url).expect("Invalid Plugin URL");
+
+            self.raw_descriptor.url = url.as_ptr();
+            self.url = Some(url);
+        }
+
+        self
     }
 
     /// The URL of this plugin's user's manual.
     ///
     /// Example: `https://dl.u-he.com/manuals/plugins/diva/Diva-user-guide.pdf`.
     #[inline]
-    fn manual_url(&self) -> Option<&CStr> {
-        None
+    pub fn manual_url(&self) -> Option<&CStr> {
+        self.manual_url.as_deref()
+    }
+
+    /// Sets the plugin's manual's URL.
+    ///
+    /// See the [`url`](PluginDescriptor::url) method documentation for more information.
+    ///
+    /// Passing an empty string as the `url` parameter will mark it as unset, making
+    /// [`url`](PluginDescriptor::url) then return `None`.
+    ///
+    /// # Panics
+    ///
+    /// This function will also panic if the given URL contains NULL-byte characters,
+    /// which are invalid.
+    pub fn with_manual_url(mut self, manual_url: &str) -> Self {
+        if manual_url.is_empty() {
+            self.raw_descriptor.manual_url = EMPTY.as_ptr();
+            self.manual_url = None;
+        } else {
+            let manual_url = CString::new(manual_url).expect("Invalid Plugin Manual URL");
+
+            self.raw_descriptor.manual_url = manual_url.as_ptr();
+            self.manual_url = Some(manual_url);
+        }
+
+        self
     }
 
     /// The URL of this plugin's support page.
     ///
     /// Example: `https://u-he.com/support/`.
     #[inline]
-    fn support_url(&self) -> Option<&CStr> {
-        None
+    pub fn support_url(&self) -> Option<&CStr> {
+        self.support_url.as_deref()
     }
 
-    /// The version of this plugin.
+    /// Sets the plugin's support URL.
+    ///
+    /// See the [`support_url`](PluginDescriptor::support_url) method documentation for more information.
+    ///
+    /// Passing an empty string as the `support_url` parameter will mark it as unset, making
+    /// [`support_url`](PluginDescriptor::support_url) then return `None`.
+    ///
+    /// # Panics
+    ///
+    /// This function will also panic if the given URL contains NULL-byte characters,
+    /// which are invalid.
+    pub fn with_support_url(mut self, support_url: &str) -> Self {
+        if support_url.is_empty() {
+            self.raw_descriptor.support_url = EMPTY.as_ptr();
+            self.support_url = None;
+        } else {
+            let support_url = CString::new(support_url).expect("Invalid Plugin Support URL");
+
+            self.raw_descriptor.support_url = support_url.as_ptr();
+            self.support_url = Some(support_url);
+        }
+
+        self
+    }
+
+    /// The version string of this plugin.
     ///
     /// While Semver-compatible version strings are preferred, this field can contain any arbitrary
     /// string.
     ///
     /// Example: `1.4.4`.
     #[inline]
-    fn version(&self) -> Option<&CStr> {
-        None
+    pub fn version(&self) -> Option<&CStr> {
+        self.version.as_deref()
+    }
+
+    /// Sets the plugin's version string.
+    ///
+    /// See the [`version`](PluginDescriptor::version) method documentation for more information.
+    ///
+    /// Passing an empty string as the `version` parameter will mark it as unset, making
+    /// [`version`](PluginDescriptor::version) then return `None`.
+    ///
+    /// # Panics
+    ///
+    /// This function will also panic if the given version string contains NULL-byte characters,
+    /// which are invalid.
+    pub fn with_version(mut self, version: &str) -> Self {
+        if version.is_empty() {
+            self.raw_descriptor.version = EMPTY.as_ptr();
+            self.version = None;
+        } else {
+            let version = CString::new(version).expect("Invalid Plugin version");
+
+            self.raw_descriptor.version = version.as_ptr();
+            self.version = Some(version);
+        }
+
+        self
     }
 
     /// A short description of this plugin.
     ///
     /// Example: `The spirit of analogue`.
     #[inline]
-    fn description(&self) -> Option<&CStr> {
-        None
+    pub fn description(&self) -> Option<&CStr> {
+        self.description.as_deref()
+    }
+
+    /// Sets the plugin's description.
+    ///
+    /// See the [`description`](PluginDescriptor::description) method documentation for more information.
+    ///
+    /// Passing an empty string as the `description` parameter will mark it as unset, making
+    /// [`description`](PluginDescriptor::description) then return `None`.
+    ///
+    /// # Panics
+    ///
+    /// This function will also panic if the given description contains NULL-byte characters,
+    /// which are invalid.
+    pub fn with_description(mut self, description: &str) -> Self {
+        if description.is_empty() {
+            self.raw_descriptor.description = EMPTY.as_ptr();
+            self.description = None;
+        } else {
+            let description = CString::new(description).expect("Invalid Plugin description");
+
+            self.raw_descriptor.description = description.as_ptr();
+            self.description = Some(description);
+        }
+
+        self
     }
 
     /// An arbitrary list of tags that can be used by hosts to classify this plugin.
@@ -84,139 +381,85 @@ pub trait PluginDescriptor: Send + Sync + 'static {
     ///
     /// Example: `"instrument", "synthesizer", "stereo"`.
     #[inline]
-    #[allow(unused)]
-    fn feature_at(&self, index: usize) -> Option<&CStr> {
-        None
+    pub fn features(&self) -> &[CString] {
+        &self.features
     }
 
-    /// The number of features exposed by this descriptor.
-    #[inline]
-    fn features_count(&self) -> usize {
-        0
-    }
-}
+    /// Sets the plugin's feature list.
+    ///
+    /// See the [`features`](PluginDescriptor::features) method documentation for more information.
+    pub fn with_features<'a>(mut self, features: impl IntoIterator<Item = &'a CStr>) -> Self {
+        self.features = features.into_iter().map(CString::from).collect();
 
-#[derive(Copy, Clone, Debug, Default)]
-pub struct StaticPluginDescriptor {
-    pub id: &'static CStr,
-    pub name: &'static CStr,
-    pub vendor: Option<&'static CStr>,
-    pub url: Option<&'static CStr>,
-    pub manual_url: Option<&'static CStr>,
-    pub support_url: Option<&'static CStr>,
-    pub version: Option<&'static CStr>,
-    pub description: Option<&'static CStr>,
-    pub features: Option<&'static [&'static CStr]>,
-}
+        self.features_array = self.features.iter().map(|f| f.as_ptr()).collect();
+        self.features_array.push(core::ptr::null());
 
-impl PluginDescriptor for StaticPluginDescriptor {
-    #[inline]
-    fn id(&self) -> &CStr {
-        self.id
+        self.raw_descriptor.features = self.features_array.as_ptr();
+
+        self
     }
 
-    #[inline]
-    fn name(&self) -> &CStr {
-        self.name
-    }
-
-    #[inline]
-    fn vendor(&self) -> Option<&CStr> {
-        self.vendor
-    }
-
-    #[inline]
-    fn url(&self) -> Option<&CStr> {
-        self.url
-    }
-
-    #[inline]
-    fn manual_url(&self) -> Option<&CStr> {
-        self.manual_url
-    }
-
-    #[inline]
-    fn support_url(&self) -> Option<&CStr> {
-        self.support_url
-    }
-
-    #[inline]
-    fn version(&self) -> Option<&CStr> {
-        self.version
-    }
-
-    #[inline]
-    fn description(&self) -> Option<&CStr> {
-        self.description
-    }
-
-    #[inline]
-    fn feature_at(&self, index: usize) -> Option<&CStr> {
-        self.features.and_then(|f| f.get(index).copied())
-    }
-
-    #[inline]
-    fn features_count(&self) -> usize {
-        self.features.map(|f| f.len()).unwrap_or(0)
-    }
-}
-
-pub struct PluginDescriptorWrapper {
-    descriptor: Box<dyn PluginDescriptor>,
-    _features_array: Vec<*const c_char>,
-    raw_descriptor: clap_plugin_descriptor,
-}
-
-// SAFETY: there is a null byte in this string.
-const EMPTY: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"\0") };
-
-impl PluginDescriptorWrapper {
-    pub fn new(descriptor: Box<dyn PluginDescriptor>) -> Self {
-        let mut features_array: Vec<_> = (0..descriptor.features_count())
-            .filter_map(|i| descriptor.feature_at(i))
-            .map(|s| s.as_ptr())
-            .collect();
-
-        features_array.push(core::ptr::null());
-
-        Self {
-            raw_descriptor: clap_plugin_descriptor {
-                clap_version: CLAP_VERSION,
-                id: descriptor.id().as_ptr(),
-                name: descriptor.name().as_ptr(),
-                vendor: descriptor.vendor().unwrap_or(EMPTY).as_ptr(),
-                url: descriptor.url().unwrap_or(EMPTY).as_ptr(),
-                manual_url: descriptor.manual_url().unwrap_or(EMPTY).as_ptr(),
-                support_url: descriptor.support_url().unwrap_or(EMPTY).as_ptr(),
-                version: descriptor.version().unwrap_or(EMPTY).as_ptr(),
-                description: descriptor.description().unwrap_or(EMPTY).as_ptr(),
-                features: features_array.as_ptr(),
-            },
-            _features_array: features_array,
-            descriptor,
-        }
-    }
-
-    #[inline]
-    pub fn descriptor(&self) -> &dyn PluginDescriptor {
-        &*self.descriptor
-    }
-
+    /// Returns the plugin descriptor as a reference to the C-FFI compatible CLAP struct.
     #[inline]
     pub fn as_raw(&self) -> &clap_plugin_descriptor {
         &self.raw_descriptor
     }
-
-    #[inline]
-    pub fn id(&self) -> &CStr {
-        self.descriptor.id()
-    }
 }
 
-// SAFETY: the whole struct is immutable.
-unsafe impl Send for PluginDescriptorWrapper {}
-// SAFETY: the whole struct is immutable.
-unsafe impl Sync for PluginDescriptorWrapper {}
+impl Clone for PluginDescriptor {
+    fn clone(&self) -> Self {
+        let id = self.id.clone();
+        let name = self.name.clone();
+
+        let vendor = self.vendor.clone();
+        let url = self.url.clone();
+        let manual_url = self.manual_url.clone();
+        let support_url = self.support_url.clone();
+        let version = self.version.clone();
+        let description = self.description.clone();
+
+        let features = self.features.clone();
+        let mut features_array: Vec<_> = features.iter().map(|f| f.as_ptr()).collect();
+
+        if !features_array.is_empty() {
+            features_array.push(core::ptr::null())
+        }
+
+        Self {
+            raw_descriptor: clap_plugin_descriptor {
+                clap_version: CLAP_VERSION,
+                id: id.as_ptr(),
+                name: name.as_ptr(),
+
+                vendor: vendor.as_deref().unwrap_or(EMPTY).as_ptr(),
+                url: url.as_deref().unwrap_or(EMPTY).as_ptr(),
+                manual_url: manual_url.as_deref().unwrap_or(EMPTY).as_ptr(),
+                support_url: support_url.as_deref().unwrap_or(EMPTY).as_ptr(),
+                version: version.as_deref().unwrap_or(EMPTY).as_ptr(),
+                description: description.as_deref().unwrap_or(EMPTY).as_ptr(),
+
+                features: if features.is_empty() {
+                    EMPTY_FEATURES.as_ptr()
+                } else {
+                    features_array.as_ptr()
+                },
+            },
+
+            id,
+            name,
+
+            vendor,
+            url,
+            manual_url,
+            support_url,
+            version,
+            description,
+
+            features,
+            features_array,
+        }
+    }
+}
 
 /// A set of standard plugin features meant to be used for a plugin descriptor's features.
 ///

--- a/plugin/src/plugin/instance.rs
+++ b/plugin/src/plugin/instance.rs
@@ -1,11 +1,11 @@
 use crate::extensions::wrapper::PluginWrapper;
 use crate::extensions::PluginExtensions;
 use crate::host::{HostHandle, HostInfo};
-use crate::plugin::descriptor::PluginDescriptorWrapper;
 use crate::plugin::instance::WrapperState::*;
 use crate::plugin::{
     AudioConfiguration, Plugin, PluginAudioProcessor, PluginError, PluginMainThread,
 };
+use crate::prelude::PluginDescriptor;
 use crate::process::{Audio, Events, Process};
 use clap_sys::plugin::{clap_plugin, clap_plugin_descriptor};
 use clap_sys::process::{clap_process, clap_process_status, CLAP_PROCESS_ERROR};
@@ -230,13 +230,13 @@ impl<'a> PluginInstance<'a> {
     /// Instantiates a plugin of a given implementation `P`.
     ///
     /// Instantiated plugins also require an [`HostInfo`] instance given by the host, and a
-    /// reference to the associated [`PluginDescriptorWrapper`].
+    /// reference to the associated [`PluginDescriptor`].
     ///
     /// See the [`PluginFactory`](crate::factory::plugin::PluginFactory)'s trait documentation for
-    /// an usage example.
+    /// a usage example.
     pub fn new<P: Plugin>(
         host_info: HostInfo<'a>,
-        descriptor: &'a PluginDescriptorWrapper,
+        descriptor: &'a PluginDescriptor,
     ) -> PluginInstance<'a> {
         // SAFETY: we guarantee that no host_handle methods are called until init() is called
         let host = unsafe { host_info.to_handle() };
@@ -251,7 +251,7 @@ impl<'a> PluginInstance<'a> {
     }
     pub fn new_with<P: Plugin>(
         host_info: HostInfo<'a>,
-        descriptor: &'a PluginDescriptorWrapper,
+        descriptor: &'a PluginDescriptor,
         initializer: impl FnOnce(HostHandle<'a>) -> Result<P::Shared<'a>, PluginError> + 'a,
     ) -> PluginInstance<'a> {
         // SAFETY: we guarantee that no host_handle methods are called until init() is called

--- a/plugin/src/plugin/instance.rs
+++ b/plugin/src/plugin/instance.rs
@@ -252,7 +252,7 @@ impl<'a, P: Plugin> PluginBoxInner<'a, P> {
 ///
 /// This type is created with its [`new`](PluginInstance::new) method when the host wants to
 /// instantiate a given plugin type, and is what needs to be returned by the
-/// [`PluginFactory::instantiate_plugin`](crate::factory::plugin::PluginFactory::instantiate_plugin) method.
+/// [`PluginFactory::instantiate_plugin`](crate::factory::plugin::PluginFactory::create_plugin) method.
 pub struct PluginInstance<'a> {
     inner: Box<clap_plugin>,
     lifetime: PhantomData<&'a clap_plugin_descriptor>,

--- a/plugin/src/process/audio/input.rs
+++ b/plugin/src/process/audio/input.rs
@@ -213,7 +213,6 @@ impl<'a, T> IntoIterator for &'a InputChannels<'a, T> {
 
 /// An iterator over all of an [`InputPort`]'s channels' sample buffers.
 pub struct InputChannelsIter<'a, T> {
-    // TODO: hide these with new() function
     pub(crate) data: Iter<'a, *mut T>,
     pub(crate) frames_count: u32,
 }

--- a/plugin/src/process/audio/output.rs
+++ b/plugin/src/process/audio/output.rs
@@ -193,7 +193,7 @@ impl<'a, S> OutputChannels<'a, S> {
         }
     }
 
-    /// Gets a read-only iterator over all of the port's channels' sample buffers.
+    /// Gets a read-only iterator over all the port's channels' sample buffers.
     #[inline]
     pub fn iter(&self) -> InputChannelsIter<S> {
         InputChannelsIter {
@@ -202,7 +202,7 @@ impl<'a, S> OutputChannels<'a, S> {
         }
     }
 
-    /// Gets an iterator over all of the port's channels' writable sample buffers.
+    /// Gets an iterator over all the port's channels' writable sample buffers.
     #[inline]
     pub fn iter_mut(&mut self) -> OutputChannelsIter<S> {
         OutputChannelsIter {


### PR DESCRIPTION
This PR overhauls the `PluginDescriptor` API on the plugin-side, and also splits off the plugin initialization methods into a new, separate and optional trait, `DefaultPluginFactory`.

* Removed the `PluginDescriptor` trait and the `StaticPluginDescriptor` and `PluginDescriptorWrapper` type, and consolidated them all in a new `PluginDescriptor` type. It is used both for declaring a plugin descriptor using a much easier-to-use builder pattern, and also for storing and accessing the inner descriptor.
* Extracted the `Plugin::get_descriptor`, `PluginShared::new` and `PluginMainThread::new` methods to a new `DefaultPluginFactory` trait, as these methods were only really used in the `SinglePluginEntry` entry type's implementation. This makes it clearer that implementing those methods are not required if a custom entry and/or `PluginFactory` is uses, which constructs the plugin instance and descriptor itself.
* Renamed the `PluginFactory::instantiate_plugin` method to `create_plugin`, to better match the CLAP naming convention.
* Changed the `PluginInstance::new` method, which now takes closures to create the plugin instances instead of relying on a trait, which allows to pass additional data during initialization.
* Added a new `PluginInstance::new_with_initializer` method, which takes a single initializer closure that creates both the shared and main_thread parts of the instance, but allows to initialize additional resources that need to be shared by both parts but require the host callbacks to be available (i.e. when `init()` is being called).