### PR TITLE
Fix `Window::as_x11:handle` (by @synchis)

### DIFF
--- a/extensions/src/gui/window.rs
+++ b/extensions/src/gui/window.rs
@@ -119,7 +119,7 @@ impl<'a> Window<'a> {
     /// Returns the window's handle as an X11 window handle, if this is an X11 window.
     /// Otherwise, this returns `None`.
     pub fn as_x11_handle(&self) -> Option<c_ulong> {
-        if self.api_type() == GuiApiType::COCOA {
+        if self.api_type() == GuiApiType::X11 {
             // SAFETY: We just checked this was a COCOA window
             unsafe { Some(self.raw.specific.x11) }
         } else {


### PR DESCRIPTION
This was not found by me, but was found (and fixed) by @synchis from the Rust Audio discord (@synchis pls lmk who/where to credit).

I couldn't find a PR fixing this, so I decided to make one (as I was already mucking about in the extension code anyways).
If that PR shows up, feel free to close this one.