### PR TITLE
clack-plugin: New FactoryWrapper helper type

### DIFF
--- a/host/Cargo.toml
+++ b/host/Cargo.toml
@@ -19,7 +19,7 @@ clack-plugin = ["dep:clack-plugin"]
 
 [dev-dependencies]
 clack-plugin = { workspace = true }
-clack-extensions = { workspace = true, features = ["clack-host", "latency", "log", "state", "timer"] }
+clack-extensions = { workspace = true, features = ["clack-host", "clack-plugin", "latency", "log", "state", "timer"] }
 
 # nih_plug = { git = "https://github.com/robbert-vdh/nih-plug", features = ["assert_process_allocs"] }
 static_assertions = "1.1.0"

--- a/host/src/factory.rs
+++ b/host/src/factory.rs
@@ -190,7 +190,15 @@ impl<'a> Iterator for PluginDescriptorsIter<'a> {
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.count as usize, Some(self.count as usize))
+        let len = self.len();
+        (len, Some(len))
+    }
+}
+
+impl ExactSizeIterator for PluginDescriptorsIter<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        (self.count - self.current_index) as usize
     }
 }
 

--- a/plugin/src/factory.rs
+++ b/plugin/src/factory.rs
@@ -23,6 +23,9 @@ mod error;
 pub mod plugin;
 mod wrapper;
 
+pub use error::FactoryWrapperError;
+pub use wrapper::FactoryWrapper;
+
 /// A base trait for plugin-side factory implementations.
 ///
 /// # Safety

--- a/plugin/src/factory/error.rs
+++ b/plugin/src/factory/error.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 use clap_sys::ext::log::{
     CLAP_LOG_ERROR, CLAP_LOG_HOST_MISBEHAVING, CLAP_LOG_PLUGIN_MISBEHAVING, clap_log_severity,
 };
@@ -42,7 +44,7 @@ impl FactoryWrapperError {
         }
     }
 
-    /// Returns a closure that maps an error to a [`PluginWrapperError::Error`] error of a given
+    /// Returns a closure that maps an error to a [`FactoryWrapperError::Error`] error of a given
     /// severity.
     ///
     /// This is a useful helper method when paired with [`Result::map_err`].

--- a/plugin/src/factory/plugin.rs
+++ b/plugin/src/factory/plugin.rs
@@ -8,7 +8,6 @@
 //!
 //! See the [`factory` module documentation](crate::factory) to learn more about factories.
 
-use crate::extensions::wrapper::handle_panic;
 use crate::factory::Factory;
 use crate::factory::error::FactoryWrapperError;
 use crate::factory::wrapper::FactoryWrapper;
@@ -17,10 +16,7 @@ use crate::plugin::{PluginDescriptor, PluginInstance};
 use clap_sys::factory::plugin_factory::{CLAP_PLUGIN_FACTORY_ID, clap_plugin_factory};
 use clap_sys::host::clap_host;
 use clap_sys::plugin::{clap_plugin, clap_plugin_descriptor};
-use std::error::Error;
 use std::ffi::CStr;
-use std::fmt::{Display, Formatter};
-use std::panic::AssertUnwindSafe;
 use std::ptr::NonNull;
 
 /// A wrapper around a given [`PluginFactory`] implementation.

--- a/plugin/src/factory/wrapper.rs
+++ b/plugin/src/factory/wrapper.rs
@@ -1,7 +1,14 @@
+#![deny(missing_docs)]
+
 use crate::extensions::wrapper::handle_panic;
 use crate::factory::error::FactoryWrapperError;
 use std::panic::AssertUnwindSafe;
 
+/// A wrapper around a `clack` factory of a given `F` type, as well as its `Raw` CLAP representation.
+///
+/// This wrapper allows to safely create a CLAP-compatible factory pointer, as well as soundly
+/// casting that pointer back to this wrapper's type, allowing to access the `F` type using the
+/// [`handle`](FactoryWrapper::handle) function.
 #[repr(C)]
 pub struct FactoryWrapper<Raw, F> {
     raw: Raw,
@@ -9,36 +16,102 @@ pub struct FactoryWrapper<Raw, F> {
 }
 
 impl<Raw, F> FactoryWrapper<Raw, F> {
+    /// Creates a new factory wrapper from a `Raw` CLAP type instance and an associated instance of `F`.
     #[inline]
     pub const fn new(raw: Raw, inner: F) -> Self {
         Self { raw, inner }
     }
 
+    /// Returns a shared reference to the `Raw` CLAP type instance.
     #[inline]
     pub const fn as_raw(&self) -> &Raw {
         &self.raw
     }
 
+    /// Returns a shared reference to the `F` factory instance.
     #[inline]
     pub const fn factory(&self) -> &F {
         &self.inner
     }
 
+    /// Provides a shared reference to the `F` factory instance to the given handler closure.
+    ///
+    /// Besides providing a reference, this function does a few extra safety checks:
+    ///
+    /// * The given `Raw` factory pointer is null-checked;
+    /// * The handler is wrapped in [`std::panic::catch_unwind`];
+    /// * Any [`FactoryWrapperError`] returned by the handler is caught.
+    ///
+    /// If any of the above safety check fails, an error message is logged through stderr (as CLAP
+    /// logging facilities are not available at the factory stage).
+    ///
+    /// Note that some safety checks (e.g. the `Raw` pointer null-checks) may result in the
+    /// closure never being called, and an error being returned only. Users of this function must
+    /// not rely on the completion of this closure for safety, and must handle this function
+    /// returning `None` gracefully.
+    ///
+    /// If all goes well, the return value of the handler closure is forwarded and returned by this
+    /// function.
+    ///
+    /// # Errors
+    ///
+    /// If any safety check failed, or any error or panic occurred inside the handler closure, this
+    /// function returns `None`, and the error message is logged.
+    ///
     /// # Safety
-    /// The plugin factory pointer must be valid
+    ///
+    /// The `raw` pointer must be created by the [`as_raw`](Self::as_raw) method, from an instance that
+    /// is still valid for the duration of the `handler` call.
+    ///
+    /// While this function does a couple of simple safety checks, only a few common
+    /// cases are actually covered (i.e. null checks), and those **must not** be relied upon: those
+    /// checks only exist to help debugging faulty hosts.
+    ///
+    /// # Example
+    ///
+    /// This is the implementation of the [`plugin_count`](crate::factory::plugin::PluginFactory::plugin_count)
+    /// callback's C wrapper.
+    ///
+    /// ```
+    /// use clap_sys::factory::plugin_factory::clap_plugin_factory;
+    /// use clack_plugin::plugin::{Plugin, PluginMainThread};
+    /// use clack_plugin::factory::{FactoryWrapper, plugin::PluginFactory};
+    ///
+    /// unsafe extern "C" fn get_plugin_count<F: PluginFactory>(factory: *const clap_plugin_factory) -> u32 {
+    ///    FactoryWrapper::<clap_plugin_factory, F>::handle(factory, |factory| {
+    ///        Ok(factory.plugin_count())
+    ///    })
+    ///    .unwrap_or(0)
+    /// }
+    /// ```
+    #[must_use]
     pub unsafe fn handle<T>(
         raw: *const Raw,
         handler: impl FnOnce(&F) -> Result<T, FactoryWrapperError>,
     ) -> Option<T> {
-        let factory = Self::from_raw(raw);
-        let result = factory.and_then(|factory| {
-            match handle_panic(AssertUnwindSafe(|| handler(factory.factory()))) {
-                Err(_) => Err(FactoryWrapperError::Panic),
-                Ok(Err(e)) => Err(e),
-                Ok(Ok(val)) => Ok(val),
-            }
-        });
+        // SAFETY: TODO
+        let factory = unsafe { raw.cast::<Self>().as_ref() };
+        let result = factory.ok_or(FactoryWrapperError::NullFactoryInstance);
 
+        let result = result.and_then(|f| f.handle_panic(handler));
+
+        Self::handle_result(result)
+    }
+
+    #[inline]
+    fn handle_panic<T>(
+        &self,
+        handler: impl FnOnce(&F) -> Result<T, FactoryWrapperError>,
+    ) -> Result<T, FactoryWrapperError> {
+        match handle_panic(AssertUnwindSafe(|| handler(&self.inner))) {
+            Err(_) => Err(FactoryWrapperError::Panic),
+            Ok(Err(e)) => Err(e),
+            Ok(Ok(val)) => Ok(val),
+        }
+    }
+
+    #[inline]
+    fn handle_result<T>(result: Result<T, FactoryWrapperError>) -> Option<T> {
         match result {
             Ok(value) => Some(value),
             Err(e) => {
@@ -47,13 +120,5 @@ impl<Raw, F> FactoryWrapper<Raw, F> {
                 None
             }
         }
-    }
-
-    /// # Safety
-    /// The plugin factory pointer must be valid (but it can be null)
-    unsafe fn from_raw<'a>(raw: *const Raw) -> Result<&'a Self, FactoryWrapperError> {
-        (raw as *const Self)
-            .as_ref()
-            .ok_or(FactoryWrapperError::NullFactoryInstance)
     }
 }


### PR DESCRIPTION
This PR adds a new `FactoryWrapper` type, a helper analogous to the existing `PluginWrapper` which helps to create custom factories by wrapping a factory's implementation in a way that allows it to be cast to and from a raw CLAP factory pointer.

This new type also provides a `handle` function, which provides the same safety checks as `PluginWrapper::handle`, but for factories instead of plugins.