### PR TITLE
Implement safe RawWindowHandle 0.6 API

### DIFF
--- a/extensions/src/gui/window.rs
+++ b/extensions/src/gui/window.rs
@@ -261,6 +261,10 @@ const _: () = {
         /// Creates a [`Window`] from a [`RawWindowHandle`].
         ///
         /// This returns [`None`] if the given window handle isn't backed by the default supported APIs.
+        ///
+        /// # Safety
+        ///
+        /// The raw window handle must be valid for the lifetime `'a`.
         #[inline]
         pub unsafe fn from_window_handle(handle: RawWindowHandle) -> Option<Self> {
             match handle {


### PR DESCRIPTION
Implement the safe RWH 0.6 API instead of the deprecated unsafe API when feature `raw-window-handle_06` is enabled.