### PR TITLE
Add `malloc()` export to `wasm32` targets only (for WCLAP)

### DIFF
--- a/plugin/src/lib.rs
+++ b/plugin/src/lib.rs
@@ -42,3 +42,22 @@ pub mod prelude {
 
 #[doc = include_str!("../../README.md")]
 const _MAIN_README_TEST: () = {};
+
+use std::ptr::null_mut;
+use std::alloc::Layout;
+
+#[cfg(target_arch="wasm32")]
+#[allow(unsafe_code)]
+#[unsafe(no_mangle)]
+pub extern "C" fn malloc(size: usize) -> *mut u8 {
+    if size == 0 {
+        return null_mut();
+    }
+
+    let Ok(layout) = Layout::from_size_align(size, 1) else {
+        return null_mut();
+    };
+
+    // SAFETY: we just checked above that size is non-zero
+    unsafe { std::alloc::alloc_zeroed(layout) }
+}


### PR DESCRIPTION
Based on the code you sent via Discord.

This works with my native and browser WCLAP hosts, when built with the command you suggested:

```
RUSTFLAGS='-C link-args=--export-table -C link-args=--growable-table' cargo build --target wasm32-unknown-unknown --release -p clack-plugin-polysynth
```