### PR TITLE
Safe `Window` handle

### DIFF
--- a/extensions/src/gui/host.rs
+++ b/extensions/src/gui/host.rs
@@ -203,16 +203,7 @@ impl PluginGui {
     }
 
     /// Embeds the plugin's GUI into the given parent window.
-    ///
-    /// # Safety
-    ///
-    /// This method does not check that the provided [`Window`] handle points to a still-valid
-    /// window object.
-    ///
-    /// It is up to the caller of this function to ensure that the underlying window object remains
-    /// valid for the lifetime of this plugin instance's GUI, i.e. up until [`destroy`](PluginGui::destroy)
-    /// is called.
-    pub unsafe fn set_parent(
+    pub fn set_parent(
         &self,
         plugin: &mut PluginMainThreadHandle,
         window: Window,
@@ -231,16 +222,7 @@ impl PluginGui {
     /// Receive instruction to stay above the given window
     ///
     /// Only applies to floating windows.
-    ///
-    /// # Safety
-    ///
-    /// This method does not check that the provided [`Window`] handle points to a still-valid
-    /// window object.
-    ///
-    /// It is up to the caller of this function to ensure that the underlying window object remains
-    /// valid for the lifetime of this plugin instance's GUI, i.e. up until [`destroy`](PluginGui::destroy)
-    /// is called.
-    pub unsafe fn set_transient(
+    pub fn set_transient(
         &self,
         plugin: &mut PluginMainThreadHandle,
         window: Window,

--- a/host/examples/cpal/src/host/gui.rs
+++ b/host/examples/cpal/src/host/gui.rs
@@ -169,7 +169,7 @@ impl Gui {
         )?;
 
         // SAFETY: We ensure the window is valid for the lifetime of the plugin window.
-        unsafe { gui.set_parent(plugin, ClapWindow::from_window(&window).unwrap())? };
+        gui.set_parent(plugin, ClapWindow::from_window(&window).unwrap())?;
         // Some plugins don't show anything until this is called, others return an error.
         let _ = gui.show(plugin);
         self.is_open = true;


### PR DESCRIPTION
This is an attempt to rework how `Window` handles lifetimes work; feel free to close this if it's not something you want.

This PR changes the guarantees provided by `Window` so that the underlying window object is guaranteed to exist as long as `Window` is alive, this means:
- Lifetime `'a` now refers to both window and api_type string lifetimes.
- Functions that **create** `Window` from raw unchecked window handles are now `unsafe`.
- Functions that **consume** `Window` (set_parent/set_transient) could now be made safe.
- It is now possible to soundly implement safe not-deprecated `raw-window-handle` v0.6 API. That means that it is possible to open GUIs on the host side entirely within safe Rust, and that it is possible to implement the GUI extension on the plugin side in safe Rust as long as you open your window in set_parent/set_transient (depending on the windowing library).

Let me know what you think