### PR TITLE
Add missing `impl Error`'s

### DIFF
--- a/extensions/src/posix_fd.rs
+++ b/extensions/src/posix_fd.rs
@@ -7,6 +7,7 @@
 use bitflags::bitflags;
 use clack_common::extensions::{Extension, HostExtensionSide, PluginExtensionSide, RawExtension};
 use clap_sys::ext::posix_fd_support::*;
+use std::error::Error;
 use std::ffi::CStr;
 use std::fmt::{Display, Formatter};
 use std::os::unix::io::RawFd;
@@ -85,6 +86,8 @@ impl Display for FdError {
         }
     }
 }
+
+impl Error for FdError {}
 
 #[cfg(feature = "clack-host")]
 mod host {

--- a/extensions/src/preset_discovery/host/extension.rs
+++ b/extensions/src/preset_discovery/host/extension.rs
@@ -3,6 +3,7 @@ use crate::utils::{cstr_from_nullable_ptr, cstr_to_nullable_ptr};
 use clack_host::extensions::prelude::*;
 use clap_sys::ext::preset_load::*;
 use clap_sys::factory::preset_discovery::clap_preset_discovery_location_kind;
+use std::error::Error;
 use std::ffi::{CStr, c_char};
 use std::fmt::{Display, Formatter};
 
@@ -59,6 +60,8 @@ impl Display for PresetLoadError {
         f.write_str("Failed to load preset from location")
     }
 }
+
+impl Error for PresetLoadError {}
 
 /// Implementation of the host side of the Preset Load extension.
 pub trait HostPresetLoadImpl {

--- a/extensions/src/render.rs
+++ b/extensions/src/render.rs
@@ -10,6 +10,7 @@
 
 use clack_common::extensions::{Extension, PluginExtensionSide, RawExtension};
 use clap_sys::ext::render::*;
+use std::error::Error;
 use std::ffi::CStr;
 use std::fmt::{Display, Formatter};
 
@@ -73,6 +74,8 @@ impl Display for PluginRenderError {
         f.write_str("Failed to set plugin's render mode.")
     }
 }
+
+impl Error for PluginRenderError {}
 
 #[cfg(feature = "clack-plugin")]
 mod plugin {


### PR DESCRIPTION
Some error types do not implement `std::error::Error`, making it annoying to use them with crates like `anyhow`.