### PR TITLE
Minor changes to `audio-ports-activation` and `param-indication` extensions.

### DIFF
--- a/extensions/src/param_indication.rs
+++ b/extensions/src/param_indication.rs
@@ -170,12 +170,13 @@ mod plugin {
         // SAFETY: panics are caught by PluginWrapper so they don't cross FFI boundary
         unsafe {
             PluginWrapper::<P>::handle(plugin, |plugin| {
-                let param_id = ClapId::new(param_id);
-                let color = *color;
+                let param_id = ClapId::from_raw(param_id)
+                    .ok_or(PluginWrapperError::InvalidParameter("param_id"))?;
+
                 plugin.main_thread().as_mut().set_mapping(
                     param_id,
                     has_mapping,
-                    color,
+                    *color,
                     CStr::from_ptr(label),
                     CStr::from_ptr(description),
                 );
@@ -197,14 +198,15 @@ mod plugin {
         // SAFETY: panics are caught by PluginWrapper so they don't cross FFI boundary
         unsafe {
             PluginWrapper::<P>::handle(plugin, |plugin| {
-                let param_id = ClapId::new(param_id);
-                let color = *color;
-                let automation_state =
-                    ParamIndicationAutomation::from_raw(automation_state).unwrap();
+                let automation_state = ParamIndicationAutomation::from_raw(automation_state)
+                    .ok_or(PluginWrapperError::InvalidParameter("automation_state"))?;
+                let param_id = ClapId::from_raw(param_id)
+                    .ok_or(PluginWrapperError::InvalidParameter("param_id"))?;
+
                 plugin
                     .main_thread()
                     .as_mut()
-                    .set_automation(param_id, automation_state, color);
+                    .set_automation(param_id, automation_state, *color);
                 Ok(())
             });
         }


### PR DESCRIPTION
Currently, `PluginAudioPortsActivationSetImpl::set_active` takes `&self` instead of `&mut self` which seems to be a left over from set_active being implemented on the `Shared` during the initial PR; this PR changes that as there is no reason for it to take `&self` now.

Another change is not panicking on invalid values passed to `audio-ports-activation` and `param-indication` implementations, which could result in plugin crashing with `panic = "abort"`; this PR changes the functions to return `PluginWrapperError::InvalidParameter` instead, to make it more in line with other extensions (like `render`)