### PR TITLE
Change `PluginAudioPortsConfig::count` return type from usize to u32

### DIFF
--- a/extensions/src/audio_ports_config/host.rs
+++ b/extensions/src/audio_ports_config/host.rs
@@ -29,11 +29,11 @@ impl AudioPortsConfigBuffer {
 
 impl PluginAudioPortsConfig {
     /// Returns the number of available [`AudioPortsConfiguration`]s.
-    pub fn count(&self, plugin: &mut PluginMainThreadHandle) -> usize {
+    pub fn count(&self, plugin: &mut PluginMainThreadHandle) -> u32 {
         match plugin.use_extension(&self.0).count {
             None => 0,
             // SAFETY: This type ensures the function pointer is valid.
-            Some(count) => unsafe { count(plugin.as_raw()) as usize },
+            Some(count) => unsafe { count(plugin.as_raw()) },
         }
     }
 


### PR DESCRIPTION
Makes it consistent with other functions in 'audio-ports' and 'audio-ports-config' extensions