### PR TITLE
fix buffer overflow when iterating through `EMPTY_FEATURES`

### DIFF
--- a/common/src/events/io/buffer.rs
+++ b/common/src/events/io/buffer.rs
@@ -59,7 +59,7 @@ pub(crate) fn byte_index_to_value_index<T>(size: usize) -> usize {
     if type_size == 0 {
         0
     } else {
-        size / type_size + if size % type_size > 0 { 1 } else { 0 }
+        size.div_ceil(type_size)
     }
 }
 

--- a/common/src/plugin/descriptor.rs
+++ b/common/src/plugin/descriptor.rs
@@ -419,6 +419,11 @@ impl OwnedCString {
     }
 
     #[inline]
+    pub const fn null() -> Self {
+        Self(std::ptr::null())
+    }
+
+    #[inline]
     pub const fn empty() -> Self {
         Self(EMPTY.as_ptr())
     }
@@ -511,8 +516,8 @@ unsafe impl Sync for OwnedCStringArray {}
 
 // Technically this doesn't need to be OwnedCString, it just needs to be (ABI-compatible with)
 // any NULL pointer that's Send + Sync.
-// I could have made a dedicated wrapper but OwnedCString::empty() fits the bill just as well :)
-static EMPTY_FEATURES: &[OwnedCString; 1] = &[OwnedCString::empty()];
+// I could have made a dedicated wrapper but OwnedCString::null() fits the bill just as well :)
+static EMPTY_FEATURES: &[OwnedCString; 1] = &[OwnedCString::null()];
 
 impl OwnedCStringArray {
     #[inline]


### PR DESCRIPTION
`OwnedCString::empty()` isn't null, but rather a pointer to a static empty C string. However, `OwnedCStringArray` needs to be null-terminated (which the host needs to rely on when iterating through plugin features) so the only element in an empty `OwnedCStringArray` needs to be null.