### PR TITLE
mark `set_cookie` and `with_cookie` as `unsafe`

### DIFF
--- a/common/src/events/event_types/param_value.rs
+++ b/common/src/events/event_types/param_value.rs
@@ -29,10 +29,10 @@ impl AsRef<UnknownEvent> for ParamValueEvent {
 }
 
 impl ParamValueEvent {
-    /// Creates a new [`ParamValueEvent`] from a `time` stamp, a parameter ID, a [`Pckn`] target,
-    /// a parameter `value` and an optional [`Cookie`].
+    /// Creates a new [`ParamValueEvent`] from a `time` stamp, a parameter ID, a [`Pckn`] target and
+    /// a parameter `value`.
     #[inline]
-    pub const fn new(time: u32, param_id: ClapId, pckn: Pckn, value: f64, cookie: Cookie) -> Self {
+    pub const fn new(time: u32, param_id: ClapId, pckn: Pckn, value: f64) -> Self {
         Self {
             inner: clap_event_param_value {
                 header: EventHeader::<Self>::new_core(time, EventFlags::empty()).into_raw(),
@@ -42,7 +42,7 @@ impl ParamValueEvent {
                 key: pckn.raw_key(),
                 channel: pckn.raw_channel(),
                 value,
-                cookie: cookie.as_raw(),
+                cookie: Cookie::empty().as_raw(),
             },
         }
     }
@@ -101,16 +101,26 @@ impl ParamValueEvent {
     }
 
     /// Sets the given [`Cookie`] to be sent alongside this event.
+    ///
+    /// # Safety
+    ///
+    /// Users *must* ensure that this cookie is either `Cookie::empty()`, or matches this event's
+    /// target parameter's current cookie when this event is delivered to the plugin.
     #[inline]
-    pub const fn set_cookie(&mut self, cookie: Cookie) {
+    pub const unsafe fn set_cookie(&mut self, cookie: Cookie) {
         self.inner.cookie = cookie.as_raw()
     }
 
     /// Builds a [`ParamValueEvent`] with the given [`Cookie`], and returns it.
     ///
     /// This is useful to use in a builder-style pattern.
+    ///
+    /// # Safety
+    ///
+    /// Users *must* ensure that this cookie is either `Cookie::empty()`, or matches this event's
+    /// target parameter's current cookie when this event is delivered to the plugin.
     #[inline]
-    pub const fn with_cookie(mut self, cookie: Cookie) -> Self {
+    pub const unsafe fn with_cookie(mut self, cookie: Cookie) -> Self {
         self.inner.cookie = cookie.as_raw();
         self
     }
@@ -164,10 +174,10 @@ impl AsRef<UnknownEvent> for ParamModEvent {
 }
 
 impl ParamModEvent {
-    /// Creates a new [`ParamModEvent`] from a `time` stamp, a parameter ID, a [`Pckn`] target,
-    /// a parameter modulation `amount` and an optional [`Cookie`].
+    /// Creates a new [`ParamModEvent`] from a `time` stamp, a parameter ID, a [`Pckn`] target and
+    /// a parameter modulation `amount`.
     #[inline]
-    pub const fn new(time: u32, param_id: ClapId, pckn: Pckn, amount: f64, cookie: Cookie) -> Self {
+    pub const fn new(time: u32, param_id: ClapId, pckn: Pckn, amount: f64) -> Self {
         Self {
             inner: clap_event_param_mod {
                 header: EventHeader::<Self>::new_core(time, EventFlags::empty()).into_raw(),
@@ -177,7 +187,7 @@ impl ParamModEvent {
                 key: pckn.raw_key(),
                 channel: pckn.raw_channel(),
                 amount,
-                cookie: cookie.as_raw(),
+                cookie: Cookie::empty().as_raw(),
             },
         }
     }
@@ -192,7 +202,7 @@ impl ParamModEvent {
 
     /// Sets the parameter ID this event targets.
     #[inline]
-    pub fn set_param_id(&mut self, param_id: ClapId) {
+    pub const fn set_param_id(&mut self, param_id: ClapId) {
         self.inner.param_id = param_id.get()
     }
 
@@ -213,7 +223,7 @@ impl ParamModEvent {
 
     /// Sets the parameter modulation amount of this event.
     #[inline]
-    pub fn set_amount(&mut self, amount: f64) {
+    pub const fn set_amount(&mut self, amount: f64) {
         self.inner.amount = amount
     }
 
@@ -236,16 +246,26 @@ impl ParamModEvent {
     }
 
     /// Sets the given [`Cookie`] to be sent alongside this event.
+    ///
+    /// # Safety
+    ///
+    /// Users *must* ensure that this cookie is either `Cookie::empty()`, or matches this event's
+    /// target parameter's current cookie when this event is delivered to the plugin.
     #[inline]
-    pub fn set_cookie(&mut self, cookie: Cookie) {
+    pub const unsafe fn set_cookie(&mut self, cookie: Cookie) {
         self.inner.cookie = cookie.as_raw()
     }
 
     /// Builds a [`ParamValueEvent`] with the given [`Cookie`], and returns it.
     ///
     /// This is useful to use in a builder-style pattern.
+    ///
+    /// # Safety
+    ///
+    /// Users *must* ensure that this cookie is either `Cookie::empty()`, or matches this event's
+    /// target parameter's current cookie when this event is delivered to the plugin.
     #[inline]
-    pub const fn with_cookie(mut self, cookie: Cookie) -> Self {
+    pub const unsafe fn with_cookie(mut self, cookie: Cookie) -> Self {
         self.inner.cookie = cookie.as_raw();
         self
     }

--- a/plugin/examples/gain-gui/src/params.rs
+++ b/plugin/examples/gain-gui/src/params.rs
@@ -7,7 +7,6 @@ use clack_plugin::events::event_types::ParamValueEvent;
 use clack_plugin::events::spaces::CoreEventSpace;
 use clack_plugin::prelude::*;
 use clack_plugin::stream::{InputStream, OutputStream};
-use clack_plugin::utils::Cookie;
 use std::cell::Cell;
 use std::ffi::CStr;
 use std::fmt::Write as _;
@@ -174,7 +173,6 @@ impl GainParamsLocal {
             GainParamsShared::PARAM_VOLUME_ID,
             Pckn::match_all(),
             self.volume.get() as f64,
-            Cookie::empty(),
         );
 
         let _ = output_events.try_push(event);

--- a/plugin/examples/gain-gui/tests/test_gain.rs
+++ b/plugin/examples/gain-gui/tests/test_gain.rs
@@ -1,7 +1,6 @@
 use clack_extensions::audio_ports::{AudioPortInfoBuffer, PluginAudioPorts};
 use clack_host::events::event_types::ParamValueEvent;
 use clack_host::prelude::*;
-use clack_host::utils::Cookie;
 use clack_plugin::entry::SinglePluginEntry;
 use clack_plugin_gain_gui::GainPlugin;
 
@@ -88,7 +87,6 @@ pub fn it_works() {
         ClapId::new(1),
         Pckn::match_all(),
         0.5,
-        Cookie::empty(),
     ));
 
     let mut input_buffers = [vec![69f32; 32], vec![69f32; 32]];

--- a/plugin/examples/gain-presets/tests/test_gain.rs
+++ b/plugin/examples/gain-presets/tests/test_gain.rs
@@ -3,7 +3,7 @@ use clack_extensions::preset_discovery::prelude::*;
 use clack_host::events::event_types::ParamValueEvent;
 use clack_host::factory::plugin::PluginFactory;
 use clack_host::prelude::*;
-use clack_host::utils::{Cookie, Timestamp, UniversalPluginId};
+use clack_host::utils::{Timestamp, UniversalPluginId};
 use clack_plugin_gain_presets::GainPluginEntry;
 use std::ffi::{CStr, CString};
 

--- a/plugin/examples/gain-presets/tests/test_gain.rs
+++ b/plugin/examples/gain-presets/tests/test_gain.rs
@@ -88,7 +88,6 @@ pub fn it_works() {
         ClapId::new(1),
         Pckn::match_all(),
         0.5,
-        Cookie::empty(),
     ));
 
     let mut input_buffers = [vec![69f32; 32], vec![69f32; 32]];

--- a/plugin/examples/gain/tests/test_gain.rs
+++ b/plugin/examples/gain/tests/test_gain.rs
@@ -2,7 +2,6 @@ use clack_extensions::audio_ports::{AudioPortInfoBuffer, PluginAudioPorts};
 use clack_host::events::event_types::ParamValueEvent;
 use clack_host::factory::plugin::PluginFactory;
 use clack_host::prelude::*;
-use clack_host::utils::Cookie;
 use clack_plugin::entry::SinglePluginEntry;
 use clack_plugin_gain::GainPlugin;
 
@@ -86,7 +85,6 @@ pub fn it_works() {
         ClapId::new(1),
         Pckn::match_all(),
         0.5,
-        Cookie::empty(),
     ));
 
     let mut input_buffers = [vec![69f32; 32], vec![69f32; 32]];


### PR DESCRIPTION
... additionally const-ifies some modulation event methods.