### PR TITLE
ensure `EventBuffer::sort` preserves insertion order of events with the same timestamp

### DIFF
--- a/common/src/events/io/buffer.rs
+++ b/common/src/events/io/buffer.rs
@@ -150,11 +150,12 @@ impl EventBuffer {
     /// It is necessary to sort the events before passing them to a plugin.
     pub fn sort(&mut self) {
         // this needs to be an unstable sort, as the std stable sort might allocate
-        self.indexes.sort_unstable_by_key(|i| {
+        self.indexes.sort_unstable_by_key(|&i| {
             // SAFETY: Registered indexes always have actual event headers written by append_header_data
             // PANIC: We used registered indexes, this should never panic
-            let event = unsafe { self.headers[*i].assume_init_ref() };
-            event.0.time
+            let event = unsafe { self.headers[i].assume_init_ref() };
+            // include the original event index, so events with the same timestamp preserve insertion order
+            (event.0.time, i)
         })
     }
 


### PR DESCRIPTION
When switching to an unstable sort here in #32, it became possible for e.g. a sequence of `[NoteOff, NoteOn]` with the same `time` and `pckn` to switch places, which changes the meaning of the event sequence. Including the original event index in the sort key should re-stabilize this sort without introducing allocations.